### PR TITLE
Added function to compare desired and current states

### DIFF
--- a/Source/VMware.vSphereDSC/Tests/Unit/Compare-Settings.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/Compare-Settings.Unit.Tests.ps1
@@ -1,0 +1,127 @@
+using module VMware.vSphereDSC
+$script:modulePath = $env:PSModulePath
+$script:unitTestsFolder = Join-Path (Join-Path (Get-Module VMware.vSphereDSC -ListAvailable).ModuleBase 'Tests') 'Unit'
+$script:moduleName = 'VMware.vSphereDSC'
+
+
+Describe 'Compare-Settings'{
+
+    BeforeAll {
+        # Arrange
+        $env:PSModulePath = $script:mockModuleLocation
+        $vimAutomationModule = Get-Module -Name VMware.VimAutomation.Core
+        if ($null -ne $vimAutomationModule -and $vimAutomationModule.Path -NotMatch 'TestHelpers')
+        {
+            throw 'The Original VMware.VimAutomation.Core Module is loaded in the current session. If you want to run the unit tests please open a new PowerShell session.'
+        }
+
+        Import-Module -Name VMware.VimAutomation.Core
+        Import-Module .\Source\VMware.vSphereDSC\VMware.vSphereDSC.Helper.psm1
+    }
+
+    AfterAll {
+        Remove-Module -Name VMware.VimAutomation.Core
+        $env:PSModulePath = $script:modulePath
+    }
+
+    Context 'Desired and current settings match'{
+        $desiredState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+        $currentState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+
+        $result = Compare-Settings -DesiredState $desiredState -CurrentState $currentState
+
+        it 'should return false' {
+            $result | should be $false
+        }
+    }
+    Context 'Desired and current settings match'{
+        $desiredState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 5"
+        }
+        $currentState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+
+        $result = Compare-Settings -DesiredState $desiredState -CurrentState $currentState
+
+        it 'should return true' {
+            $result | should be $true
+        }
+    }
+    Context 'Desired state has additional setting'{
+        $desiredState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+            key4 = "value 4"
+        }
+        $currentState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+
+        $result = Compare-Settings -DesiredState $desiredState -CurrentState $currentState
+
+        it 'should return true' {
+            $result | should be $true
+        }
+    }
+    Context 'Current state has additional setting'{
+        $desiredState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+        $currentState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+            key4 = "value 4"
+        }
+
+        $result = Compare-Settings -DesiredState $desiredState -CurrentState $currentState
+
+        it 'should return false' {
+            $result | should be $false
+        }
+    }
+    Context 'Current state not supplied'{
+        $desiredState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+
+        $result = Compare-Settings -DesiredState $desiredState
+
+        it 'should return true' {
+            $result | should be $true
+        }
+    }
+    Context 'Desired state not supplied'{
+        $currentState = @{
+            key1 = "value 1"
+            key2 = "value 2"
+            key3 = "value 3"
+        }
+
+        $result = Compare-Settings -CurrentState $currentState
+
+        it 'should return false' {
+            $result | should be $false
+        }
+    }
+}

--- a/Source/VMware.vSphereDSC/VMware.vSphereDSC.Helper.psm1
+++ b/Source/VMware.vSphereDSC/VMware.vSphereDSC.Helper.psm1
@@ -178,3 +178,32 @@ function Update-PerfInterval {
 
     $PerformanceManager.UpdatePerfInterval($PerformanceInterval)
 }
+
+function Compare-Settings
+{
+    <#
+    .SYNOPSIS
+    Compare settings between current and desired states
+    .DESCRIPTION
+    This compares the current and desired states by comparing the configuration values specified in the desired state to the current state.
+    If a value is not specified in the desired state it is not assessed against the current state.
+
+    .PARAMETER DesiredState
+    Desired state configuration object.
+
+    .PARAMETER CurrentState
+    Current state configuration object.
+    #>
+    [CmdletBinding()]
+    param(
+        $DesiredState,
+        $CurrentState
+    )
+
+    foreach ($key in $DesiredState.Keys) {
+        if ($CurrentState.$key -ne $DesiredState.$key ){
+            return $true
+        }
+    }
+    return $false
+}


### PR DESCRIPTION
- New function compare-settings has been created to remove the repeated code used to compare desired and current states
- Using the function should improve testability
- Refactured NTP resource as example
- Unit test created for the function

Signed-off-by: Brett Johnson <brett@sdbrett.com>