### PR TITLE
VMHostVSS 1st draft

### DIFF
--- a/Documentation/DSCResources/VMHostVss/VMHostVss.md
+++ b/Documentation/DSCResources/VMHostVss/VMHostVss.md
@@ -1,0 +1,70 @@
+# VMHostTpsSettings
+
+## Parameters
+
+| Parameter | Attribute | DataType | Description | Allowed Values |
+| --- | --- | --- | --- | --- |
+| **Server** | Key | string | Name of the Server we are trying to connect to. The Server can be a vCenter or ESXi. ||
+| **Name** | Key | string | Name of the VMHost to configure. ||
+| **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
+| **ShareScanTime** | Optional | int | Share Scan Time Advanced Setting value. ||
+| **ShareScanGHz** | Optional | int | Share Scan GHz Advanced Setting value. ||
+| **ShareRateMax** | Optional | int | Share Rate Max Advanced Setting value. ||
+| **ShareForceSalting** | Optional | int | Share Force Salting Advanced Setting value. ||
+
+## Description
+
+The resource is used to configure TPS Settings of a ESXi host.
+
+## Examples
+
+### Example 1
+
+Updates the ShareScanTime and ShareForceSalting Advanced Settings values of the passed ESXi host.
+
+````powershell
+param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Name,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Server,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $User,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $Password
+)
+
+$script:configurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+Configuration VMHostVss_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        $Password = $Password | ConvertTo-SecureString -AsPlainText -Force
+        $Credential = New-Object System.Management.Automation.PSCredential($User, $Password)
+
+        VMHostVss vmHostVSS
+        {
+            Name = $Name
+            Server = $Server
+            Credential = $Credential
+            ShareScanTime = 50
+            ShareForceSalting = 1
+        }
+    }
+}
+````

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVss.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVss.ps1
@@ -1,0 +1,216 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVss : VMHostBaseDSC {
+    <#
+    .DESCRIPTION
+
+    Value indicating if the VSS should be Present or Absent.
+    #>
+    [DscProperty(Mandatory)]
+    [Ensure] $Ensure
+
+    <#
+    .DESCRIPTION
+
+    The name of the VSS.
+    #>
+    [DscProperty(Key)]
+    [string] $VssName
+
+    <#
+    .DESCRIPTION
+
+    The maximum transmission unit (MTU) associated with this virtual switch in bytes.
+    #>
+    [DscProperty()]
+    [int] $Mtu
+
+    <#
+    .DESCRIPTION
+
+    The number of ports that this virtual switch currently has.
+    #>
+    [DscProperty()]
+    [int] $NumPorts
+
+    <#
+    .DESCRIPTION
+
+    The virtual switch key.
+    #>
+    [DscProperty(NotConfigurable)]
+    [string] $Key
+
+    <#
+    .DESCRIPTION
+
+    The number of ports that are available on this virtual switch.
+    #>
+    [DscProperty(NotConfigurable)]
+    [int] $NumPortsAvailable
+
+    <#
+    .DESCRIPTION
+
+    The set of physical network adapters associated with this bridge.
+    #>
+    [DscProperty(NotConfigurable)]
+    [string[]] $Pnic
+
+    <#
+    .DESCRIPTION
+
+    The list of port groups configured for this virtual switch.
+    #>
+    [DscProperty(NotConfigurable)]
+    [string[]] $PortGroup
+
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $this.ConnectVIServer()
+        $vmHost = $this.GetVMHost()
+
+        $this.UpdateVss($vmHost)
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $this.ConnectVIServer()
+        $vmHost = $this.GetVMHost()
+        $vss = $this.GetVss($vmHost)
+
+        if ($this.Ensure -eq [Ensure]::Present) {
+            return ($null -ne $vss -and $this.Equals($vss))
+        }
+        else {
+            return ($null -eq $vss)
+        }
+    }
+
+    [VMHostVss] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVss]::new()
+        $result.Server = $this.Server
+        $result.Credential = $this.Credential
+        $result.Name = $this.Name
+        $result.Ensure = $this.Ensure
+
+        $this.ConnectVIServer()
+        $vmHost = $this.GetVMHost()
+        $this.PopulateResult($vmHost, $result)
+
+        return $result
+    }
+
+    <#
+    .DESCRIPTION
+
+    Returns a boolean value indicating if the VMHostService should to be updated.
+    #>
+    [bool] Equals($vss) {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $vssTest = @()
+        $vssTest += ($vss.Name -eq $this.VssName)
+        $vssTest += ($vss.MTU -eq $this.MTU)
+        $vssTest += ($vss.NumPorts -eq $this.NumPorts)
+
+        return ($vssTest -notcontains $false)
+    }
+
+    <#
+    .DESCRIPTION
+
+    Returns the desired virtual switch if it is present on the server otherwise returns $null.
+    #>
+    [PSObject]GetVss($vmHost) {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $hostNetSys = Get-View -Server $this.Connection $vmHost.ExtensionData.ConfigManager.NetworkSystem
+        $vss = $hostNetSys.NetworkInfo.Vswitch |
+            Where-Object {$_.Name -eq $this.VssName}
+
+        return $vss
+    }
+
+    <#
+    .DESCRIPTION
+
+    Updates the configuration of the virtual switch.
+    #>
+    [void] UpdateVSS($vmHost) {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $vssConfigArgs = @{
+            Name = $this.VssName
+            Mtu = $this.Mtu
+            NumPorts = $this.NumPorts
+            Operation = 'add'
+        }
+        $vss = $this.GetVss($vmHost)
+        if ($this.Ensure -eq 'Present') {
+            if ($null -ne $vss) {
+                if ($this.Equals($vss)) {
+                    return
+                }
+                $vssConfigArgs.Operation = 'edit'
+            }
+            else {
+                $vssConfigArgs.Operation = 'add'
+            }
+        }
+        else {
+            if ($null -eq $vss) {
+                return
+            }
+            $vssConfigArgs.Operation = 'remove'
+        }
+
+        $vssConfig = New-VssConfig @vssConfigArgs
+        $hostNetSys = Get-View -Server $this.Connection $vmHost.ExtensionData.ConfigManager.NetworkSystem
+        try {
+            Update-Network -NetworkSystem $hostNetSys -Type 'VSS' -VssConfig $vssConfig
+        }
+        catch {
+            Write-Error "The virtual switch Config could not be updated: $($PSItem.ToString())"
+        }
+
+        return
+    }
+
+    <#
+    .DESCRIPTION
+
+    Populates the result returned from the Get() method with the values of the virtual switch.
+    #>
+    [void] PopulateResult($vmHost, $vmHostVSS) {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $currentVss = $this.GetVss($vmHost)
+        $vmHostVSS.Key = $currentVss.Key
+        $vmHostVSS.Mtu = $currentVss.Mtu
+        $vmHostVSS.VssName = $currentVss.Name
+        $vmHostVSS.Numports = $currentVss.NumPorts
+        $vmHostVSS.NumPortsAvailable = $currentVss.NumPortsAvailable
+        $vmHostVSS.Pnic = $currentVss.Pnic
+        $vmHostVSS.Portgroup = $currentVss.Portgroup
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssAutoBridge.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssAutoBridge.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssAutoBridge : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssAutoBridge] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssAutoBridge]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssBondBridge.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssBondBridge.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssBondBridge : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssBondBridge] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssBondBridge]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssSimpleBridge.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssBridge/VMHostVssSimpleBridge.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssSimpleBridge : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssSimpleBridge] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssSimpleBridge]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssOffload.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssOffload.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssOffload : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssOffload] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssOffload]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssSecurity.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssSecurity.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssSecurity : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssSecurity] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssSecurity]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssShaping.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssShaping.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssShaping : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssShaping] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssShaping]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssTeaming.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostVss/VMHostVssTeaming.ps1
@@ -1,0 +1,36 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssTeaming : VMHostBaseDSC {
+    [void] Set() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+    }
+
+    [bool] Test() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        return $true
+    }
+
+    [VMHostVssTeaming] Get() {
+        Write-Verbose -Message "$(Get-Date) $($s = Get-PSCallStack; "Entering {0}" -f $s[0].FunctionName)"
+
+        $result = [VMHostVssTeaming]::new()
+        return $result
+    }
+}

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVss/VMHostVss_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVss/VMHostVss_Config.ps1
@@ -1,0 +1,106 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $User,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Password
+)
+
+$Password = $Password | ConvertTo-SecureString -AsPlainText -Force
+$script:vmHostCredential = New-Object System.Management.Automation.PSCredential($User, $Password)
+
+$script:VssName = 'VSSDSC'
+$script:NumPorts = 1
+$script:Mtu = 1500
+$script:Present = 'Present'
+$script:Absent = 'Absent'
+
+$script:configurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+        }
+    )
+}
+
+$moduleFolderPath = (Get-Module VMware.vSphereDSC -ListAvailable).ModuleBase
+$integrationTestsFolderPath = Join-Path (Join-Path $moduleFolderPath 'Tests') 'Integration'
+
+Configuration VMHostVss_New_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVss vmHostVssSettings {
+            Name = $Name
+            Server = $Server
+            Credential = $script:vmHostCredential
+            Ensure = $script:Present
+            VssName = $script:VssName
+            Mtu = $script:Mtu
+            NumPorts = $script:NumPorts
+        }
+    }
+}
+
+Configuration VMHostVss_Modify_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVss vmHostVssSettings {
+            Name = $Name
+            Server = $Server
+            Credential = $script:vmHostCredential
+            Ensure = $script:Present
+            VssName = $script:VssName
+            Mtu = $script:Mtu + 1
+            NumPorts = $script:NumPorts + 1
+        }
+    }
+}
+
+Configuration VMHostVss_Remove_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVss vmHostVssSettings {
+            Name = $Name
+            Server = $Server
+            Credential = $script:vmHostCredential
+            Ensure = $script:Absent
+            VssName = $script:VssName
+            Mtu = $script:Mtu
+            NumPorts = $script:NumPorts
+        }
+    }
+}
+
+VMHostVss_New_Config -OutputPath "$integrationTestsFolderPath\VMHostVss_New_Config" -ConfigurationData $script:configurationData
+VMHostVss_Modify_Config -OutputPath "$integrationTestsFolderPath\VMHostVss_Modify_Config" -ConfigurationData $script:configurationData
+VMHostVss_Remove_Config -OutputPath "$integrationTestsFolderPath\VMHostVss_Remove_Config" -ConfigurationData $script:configurationData

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostVss/VMHostVss.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostVss/VMHostVss.Integration.Tests.ps1
@@ -1,0 +1,229 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Name,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $User,
+
+    [Parameter(Mandatory = $true)]
+    [string]
+    $Password
+)
+
+$script:dscResourceName = 'VMHostVss'
+$script:dscConfig = $null
+$script:moduleFolderPath = (Get-Module VMware.vSphereDSC -ListAvailable).ModuleBase
+$script:integrationTestsFolderPath = Join-Path (Join-Path (Join-Path $moduleFolderPath 'Tests') 'Integration') $script:dscResourceName
+
+$script:configWithNewVss = "$($script:dscResourceName)_New_Config"
+$script:configWithModifyVss = "$($script:dscResourceName)_Modify_Config"
+$script:configWithRemoveVss = "$($script:dscResourceName)_Remove_Config"
+
+$script:connection = Connect-VIServer -Server $Server -User $User -Password $Password
+$script:vmHost = $null
+
+$script:VssName = 'VSSDSC'
+$script:NumPorts = 1
+$script:Mtu = 1500
+$script:Present = 'Present'
+$script:Absent = 'Absent'
+
+$script:resourceWithNewVss = @{
+    Name = $Name
+    Server = $Server
+    Ensure = $script:Present
+    VssName = $script:VssName
+    Mtu = $script:Mtu
+    NumPorts = $script:NumPorts
+}
+$script:resourceWithModifyVss = @{
+    Name = $Name
+    Server = $Server
+    Ensure = $script:Present
+    VssName = $script:VssName
+    Mtu = $script:Mtu + 1
+    NumPorts = $script:NumPorts + 1
+}
+$script:resourceWithRemoveVss = @{
+    Name = $Name
+    Server = $Server
+    Ensure = $script:Absent
+    VssName = $script:VssName
+    Mtu = $script:Mtu
+    NumPorts = $script:NumPorts
+}
+
+. $script:configurationFile -Name $Name -Server $Server -User $User -Password $Password
+
+$script:mofFileWithNewVss = "$script:integrationTestsFolderPath\$($script:configWithNewVss)\"
+$script:mofFileWithModifyVss = "$script:integrationTestsFolderPath\$($script:configWithModifyVss)\"
+$script:mofFileWithRemoveVss = "$script:integrationTestsFolderPath\$($script:configWithRemoveVss)\"
+
+Describe "$($script:dscResourceName)_Integration" {
+    Context "When using configuration $($script:configWithNewVss)" {
+        BeforeEach {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileWithNewVss
+                ComputerName = 'localhost'
+                Wait = $true
+                Force = $true
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParameters
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            # Assert
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileWithNewVss
+                ComputerName = 'localhost'
+                Wait = $true
+                Force = $true
+            }
+            Start-DscConfiguration @startDscConfigurationParameters | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            # Assert
+            { Get-DscConfiguration } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration and all the parameters should match' {
+            # Act
+            $configuration = Get-DscConfiguration
+
+            # Assert
+            $configuration.VssName | Should -Be $script:resourceWithNewVss.VssName
+            $configuration.NumPorts | Should -Be $script:resourceWithNewVss.NumPorts
+            $configuration.Mtu | Should -Be $script:resourceWithNewVss.Mtu
+            $configuration.Ensure | Should -Be $script:resourceWithNewVss.Ensure
+        }
+
+        It 'Should return $true when Test-DscConfiguration is run' {
+            # Arrange && Act && Assert
+            Test-DscConfiguration | Should -Be $true
+        }
+    }
+
+    Context "When using configuration $($script:configWithModifyVss)" {
+        BeforeEach {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileWithModifyVss
+                ComputerName = 'localhost'
+                Wait = $true
+                Force = $true
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParameters
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            # Assert
+            {
+                $startDscConfigurationParameters = @{
+                    Path = $script:mofFileWithWithModifyVss
+                    ComputerName = 'localhost'
+                    Wait = $true
+                    Force = $true
+                }
+                Start-DscConfiguration @startDscConfigurationParameters | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                # Assert
+                { Get-DscConfiguration} | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration and all the parameters should match' {
+                # Act
+                $configuration = Get-DscConfiguration
+
+                # Assert
+                $configuration.VssName | Should -Be $script:resourceWithModifyVss.VssName
+                $configuration.NumPorts | Should -Be $script:resourceWithModifyVss.NumPorts
+                $configuration.Mtu | Should -Be $script:resourceWithModifyVss.Mtu
+                $configuration.Ensure | Should -Be $script:resourceWithModifyVss.Ensure
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                # Arrange && Act && Assert
+                Test-DscConfiguration | Should -Be $true
+            }
+        }
+    }
+
+    Context "When using configuration $($script:configWithRemoveVss)" {
+        BeforeEach {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileWithRemoveVss
+                ComputerName = 'localhost'
+                Wait = $true
+                Force = $true
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParameters
+        }
+
+        It 'Should compile and apply the MOF without throwing' {
+            # Assert
+            {
+                $startDscConfigurationParameters = @{
+                    Path = $script:mofFileWithRemoveVss
+                    ComputerName = 'localhost'
+                    Wait = $true
+                    Force = $true
+                }
+                Start-DscConfiguration @startDscConfigurationParameters | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                # Assert
+                { Get-DscConfiguration } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration and all the parameters should match' {
+                # Act
+                $configuration = Get-DscConfiguration
+
+                # Assert
+                $configuration.VssName | Should -Be $script:resourceWithRemoveVss.VssName
+                $configuration.NumPorts | Should -Be $script:resourceWithRemoveVss.NumPorts
+                $configuration.Mtu | Should -Be $script:resourceWithRemoveVss.Mtu
+                $configuration.Ensure | Should -Be $script:resourceWithRemoveVss.Ensure
+            }
+
+            It 'Should return $true when Test-DscConfiguration is run' {
+                # Arrange && Act && Assert
+                Test-DscConfiguration | Should -Be $true
+            }
+        }
+    }
+}

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
@@ -50,6 +50,27 @@ Add-Type -TypeDefinition @"
         UseSystemProxy,
         Unset
     }
+    public class ManagedObjectReference : System.IEquatable<ManagedObjectReference>
+    {
+        public string Type { get; set; }
+
+        public string Value { get; set; }
+
+        public bool Equals(ManagedObjectReference moRef)
+        {
+            return moRef != null && this.Type == moRef.Type && this.Value == moRef.Value;
+        }
+
+        public override bool Equals(object moRef)
+        {
+            return this.Equals(moRef as ManagedObjectReference);
+        }
+
+        public override int GetHashCode()
+        {
+            return (this.Type + "_" + this.Value).GetHashCode();
+        }
+    }
 
     public class VIServer : System.IEquatable<VIServer>
     {
@@ -224,6 +245,8 @@ Add-Type -TypeDefinition @"
     public class HostNetworkInfo
     {
         public HostDnsConfig DnsConfig { get; set; }
+
+        public HostVirtualSwitch[] vSwitch { get; set; }
     }
 
     public class HostConfig
@@ -264,6 +287,8 @@ Add-Type -TypeDefinition @"
     {
         // Property used only for comparing HostNetworkSystem objects.
         public string Id { get; set; }
+
+        public HostNetworkInfo NetworkInfo { get; set; }
 
         public void UpdateDnsConfig(HostDnsConfig dnsConfig)
         {
@@ -627,7 +652,186 @@ Add-Type -TypeDefinition @"
                     this.InvalidCertificateAction.ToString() + "_" + this.ProxyPolicy.ToString() + this.WebOperationTimeoutSeconds).GetHashCode();
         }
     }
- }
+
+    public class HostVirtualSwitch : System.IEquatable<HostVirtualSwitch>
+    {
+        public HostVirtualSwitch()
+        {
+        }
+
+        public string Key { get; set; }
+
+        public int Mtu { get; set; }
+
+        public string Name { get; set; }
+
+        public int NumPorts { get; set; }
+
+        public int NumPortsAvailable { get; set; }
+
+        public string[] Pnic { get; set; }
+
+        public string[] Portgroup { get; set; }
+
+        public bool Equals(HostVirtualSwitch hostVirtualSwitch)
+        {
+            return hostVirtualSwitch != null && this.Name == hostVirtualSwitch.Name && this.NumPorts == hostVirtualSwitch.NumPorts &&
+                this.Mtu == hostVirtualSwitch.Mtu;
+        }
+
+        public override bool Equals(object hostVirtualSwitch)
+        {
+            return this.Equals(hostVirtualSwitch as HostVirtualSwitch);
+        }
+
+         public override int GetHashCode()
+        {
+            return (this.Key + "_" +
+                    this.Mtu + "_" +
+                    this.Name + "_" +
+                    this.NumPorts + "_").GetHashCode();
+        }
+    }
+
+    public class HostVirtualSwitchBridge
+    {}
+
+    public class HostVirtualSwitchAutoBridge : HostVirtualSwitchBridge
+    {
+        public string[] ExcludedNicDevice { get; set; }
+    }
+
+    public class HostVirtualSwitchBeaconConfig
+    {
+        public int Interval { get; set; }
+    }
+
+    public class LinkDiscoveryProtocolConfig
+    {
+        public string Operation { get; set; }
+
+        public string Protocol { get; set; }
+    }
+
+    public class HostVirtualSwitchBondBridge : HostVirtualSwitchBridge
+    {
+        public HostVirtualSwitchBeaconConfig Beacon { get; set; }
+
+        public LinkDiscoveryProtocolConfig LinkDiscoveryProtocolConfig { get; set; }
+
+        public string[] NicDevice { get; set; }
+    }
+
+    public class HostVirtualSwitchSimpleBridge : HostVirtualSwitchBridge
+    {
+        public string[] NicDevice { get; set; }
+    }
+
+    public class HostNicFailureCriteria
+    {
+        public bool CheckBeacon { get; set; }
+
+        public bool CheckDuplex { get; set; }
+
+        public bool CheckErrorPercent { get; set; }
+
+        public string CheckSpeed { get; set; }
+
+        public bool FullDuplex { get; set; }
+
+        public int Percentage { get; set; }
+
+        public int Speed { get; set; }
+    }
+
+    public class HostNicOrderPolicy
+    {
+        public string[] ActiveNic { get; set; }
+
+        public string[] StandbyNic { get; set; }
+    }
+
+    public class HostNicTeamingPolicy
+    {
+        public HostNicFailureCriteria FailureCriteria { get; set; }
+
+        public HostNicOrderPolicy NicOrder { get; set; }
+
+        public bool NotifySwitches { get; set; }
+
+        public string Policy { get; set; }
+
+        public bool ReversePolicy { get; set; }
+
+        public bool RollingOrder { get; set; }
+    }
+
+    public class HostNetOffloadCapabilities
+    {
+        public bool CsumOffload { get; set; }
+
+        public bool TcpSegmentation { get; set; }
+
+        public bool ZeroCopyXmit { get; set; }
+    }
+
+    public class HostNetworkSecurityPolicy
+    {
+        public bool AllowPromiscuous { get; set; }
+
+        public bool ForgedTransmits { get; set; }
+
+        public bool MacChanges{ get; set; }
+    }
+
+    public class HostNetworkTrafficShapingPolicy
+    {
+        public long AverageBandwidth { get; set; }
+
+        public long BurstSize { get; set; }
+
+        public bool Enabled{ get; set; }
+
+        public long PeakBandwidth { get; set; }
+    }
+
+    public class HostNetworkPolicy
+    {
+        public HostNicTeamingPolicy NicTeaming { get; set; }
+
+        public HostNetOffloadCapabilities OffloadPolicy { get; set; }
+
+        public HostNetworkSecurityPolicy Security { get; set; }
+
+        public HostNetworkTrafficShapingPolicy ShapingPolicy { get; set; }
+    }
+
+    public class HostVirtualSwitchSpec
+    {
+        public HostVirtualSwitchBridge Bridge { get; set; }
+
+        public int Mtu { get; set; }
+
+        public int NumPorts { get; set; }
+
+        public HostNetworkPolicy Policy { get; set; }
+    }
+    public class HostVirtualSwitchConfig
+    {
+        public string ChangeOperation { get; set; }
+
+        public string Name { get; set; }
+
+        public HostVirtualSwitchSpec Spec { get; set; }
+    }
+
+    public class HostNetworkConfigResult
+    {
+        public string[] ConsoleVnicDevice { get; set; }
+
+        public string[] VnicDevice { get; set; }
+    }
+  }
 "@
 
 function Connect-VIServer {
@@ -654,6 +858,7 @@ function Get-View {
         [PSObject] $VIObject
     )
 
+    Write-Host "In TestHelper module"
     return $null
 }
 

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostVss/VMHostVss.Unit.Test1.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostVss/VMHostVss.Unit.Test1.ps1
@@ -1,0 +1,835 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+using module VMware.vSphereDSC
+
+function BeforeAllTests {
+    $script:modulePath = $env:PSModulePath
+    $script:unitTestsFolder = Join-Path (Join-Path (Get-Module VMware.vSphereDSC -ListAvailable).ModuleBase 'Tests') 'Unit'
+    $script:mockModuleLocation = "$script:unitTestsFolder\TestHelpers"
+
+    $script:moduleName = 'VMware.vSphereDSC'
+    $script:resourceName = 'VMHostVss'
+
+    $user = 'user'
+    $password = 'password' | ConvertTo-SecureString -AsPlainText -Force
+    $credential = New-Object System.Management.Automation.PSCredential($user, $password)
+
+    $global:resourceProperties = @{
+        Name = '10.23.82.112'
+        Server = '10.23.82.112'
+        Credential = $credential
+        Ensure = 'Present'
+        VssName = 'DSCTest'
+        NumPorts = 1
+        Mtu = 1500
+        Key = 'VSS'
+        NumPortsAvailable = 1
+        Pnic = @('vmnic1', 'vmnic2')
+        Portgroup = @('Portgroup1', 'Portgroup2')
+    }
+
+    $env:PSModulePath = $script:mockModuleLocation
+    $vimAutomationModule = Get-Module -Name VMware.VimAutomation.Core
+    if ($null -ne $vimAutomationModule -and $vimAutomationModule.Path -NotMatch 'TestHelpers') {
+        throw 'The Original VMware.VimAutomation.Core Module is loaded in the current session. If you want to run the unit tests please open a new PowerShell session.'
+    }
+
+    Import-Module -Name VMware.VimAutomation.Core
+}
+
+function AfterAllTests {
+    Remove-Variable -Name resourceProperties -Scope Global -Confirm:$false
+    Remove-Module -Name VMware.VimAutomation.Core
+    $env:PSModulePath = $script:modulePath
+}
+
+# Calls the function to Import the mocked VMware.VimAutomation.Core module before all tests.
+Try {
+    BeforeAllTests
+
+    Describe 'VMHostVss\Set'  -Tag 'Set' {
+        Context 'Present + VSS does not exist' {
+            BeforeAll {
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = $null
+                            }
+                        }
+                    )
+                }
+                $vssConfigMock = {
+                    return [VMware.Vim.HostVirtualSwitchConfig] @{
+                        Name = $global:resourceProperties.VssName
+                        ChangeOperation = 'add'
+                        Spec = [VMware.Vim.HostVirtualSwitchSpec] @{
+                            Mtu = $global:resourceProperties.Mtu
+                            NumPorts = $global:resourceProperties.NumPorts
+                        }
+                    }
+                }
+                $updateNetworkMock = {
+                    return [VMware.Vim.HostNetworkConfigResult] @{
+                        ConsoleVnicDevice = $null
+                        VnicDevice = $null
+                    }
+                }
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+            Mock -CommandName New-VssConfig -MockWith $vssConfigMock -ModuleName $script:moduleName
+            Mock -CommandName Update-Network -MockWith $updateNetworkMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should call the Connect-VIServer mock with the passed server and credentials once' {
+                # Act
+                $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Connect-VIServer `
+                    -ParameterFilter { $Server -eq $global:resourceProperties.Server -and $Credential -eq $global:resourceProperties.Credential } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-VMHost with the passed server and name once' {
+                # Act
+                $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-VMHost `
+                    -ParameterFilter { $Server -eq $vCenter -and $Name -eq $global:resourceProperties.Name } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-View with the passed server and id twice' {
+                # Act
+                $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-View `
+                    -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $networkSystemObject } `
+                    -ModuleName $script:moduleName -Exactly 2 -Scope It
+            }
+
+            It 'Should call New-VssConfig once with operation Add' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName New-VssConfig `
+                    -ParameterFilter { $Name -eq $global:resourceProperties.VssName -and $Operation -eq 'add' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Update-Network once with type Add' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Update-Network `
+                    -ParameterFilter { $Type -eq 'VSS' -and $VssConfig.ChangeOperation -eq 'add' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+        }
+
+        Context 'Present + VSS does exist with different properties' {
+            BeforeAll {
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu + 1
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts + 1
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+                $vssConfigMock = {
+                    return [VMware.Vim.HostVirtualSwitchConfig] @{
+                        Name = $global:resourceProperties.VssName
+                        ChangeOperation = 'edit'
+                        Spec = [VMware.Vim.HostVirtualSwitchSpec] @{
+                            Mtu = $global:resourceProperties.Mtu
+                            NumPorts = $global:resourceProperties.NumPorts
+                        }
+                    }
+                }
+                $updateNetworkMock = {
+                    return [VMware.Vim.HostNetworkConfigResult] @{
+                        ConsoleVnicDevice = $null
+                        VnicDevice = $null
+                    }
+                }
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+            Mock -CommandName New-VssConfig -MockWith $vssConfigMock -ModuleName $script:moduleName
+            Mock -CommandName Update-Network -MockWith $updateNetworkMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should call New-VssConfig once with operation Edit' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName New-VssConfig `
+                    -ParameterFilter { $Name -eq $global:resourceProperties.VssName -and $Operation -eq 'edit' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Update-Network once with type Edit' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Update-Network `
+                    -ParameterFilter { $Type -eq 'VSS' -and $VssConfig.ChangeOperation -eq 'edit' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+        }
+
+        Context 'Absent + VSS exists' {
+            BeforeAll {
+                $global:resourceProperties.Ensure = 'Absent'
+
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+                $vssConfigMock = {
+                    return [VMware.Vim.HostVirtualSwitchConfig] @{
+                        Name = $global:resourceProperties.VssName
+                        ChangeOperation = 'remove'
+                        Spec = [VMware.Vim.HostVirtualSwitchSpec] @{
+                            Mtu = $global:resourceProperties.Mtu
+                            NumPorts = $global:resourceProperties.NumPorts
+                        }
+                    }
+                }
+                $updateNetworkMock = {
+                    return [VMware.Vim.HostNetworkConfigResult] @{
+                        ConsoleVnicDevice = $null
+                        VnicDevice = $null
+                    }
+                }
+            }
+
+            AfterAll {
+                $global:resourceProperties.Ensure = 'Present'
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+            Mock -CommandName New-VssConfig -MockWith $vssConfigMock -ModuleName $script:moduleName
+            Mock -CommandName Update-Network -MockWith $updateNetworkMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should call New-VssConfig once with operation Remove' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName New-VssConfig `
+                    -ParameterFilter { $Name -eq $global:resourceProperties.VssName -and $Operation -eq 'remove' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Update-Network once with type Remove' {
+                # Act
+                $result = $resource.Set()
+
+                # Assert
+                Assert-MockCalled -CommandName Update-Network `
+                    -ParameterFilter { $Type -eq 'VSS' -and $VssConfig.ChangeOperation -eq 'remove' } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+        }
+    }
+
+    Describe 'VMHostVss\Test' -Tag 'Test' {
+        Context 'Present + VSS does not exist' {
+            BeforeAll {
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = $null
+                            }
+                        }
+                    )
+                }
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should call the Connect-VIServer mock with the passed server and credentials once' {
+                # Act
+                $resource.Test()
+
+                # Assert
+                Assert-MockCalled -CommandName Connect-VIServer `
+                    -ParameterFilter { $Server -eq $global:resourceProperties.Server -and $Credential -eq $global:resourceProperties.Credential } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-VMHost with the passed server and name once' {
+                # Act
+                $resource.Test()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-VMHost `
+                    -ParameterFilter { $Server -eq $vCenter -and $Name -eq $global:resourceProperties.Name } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-View with the passed server and id once' {
+                # Act
+                $resource.Test()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-View `
+                    -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $networkSystemObject } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should return $false (The desired VSS does not exist)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $false
+            }
+        }
+
+        Context 'Present + VSS does exist with different properties' {
+            BeforeAll {
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu + 1
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts + 1
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should return $false (The desired VSS is not configured correctly)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $false
+            }
+        }
+
+        Context 'Present + VSS does exist with the same properties' {
+            BeforeAll {
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should return $true (The desired VSS is configured correctly)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $true
+            }
+        }
+
+        Context 'Absent + VSS does not exist' {
+            BeforeAll {
+                $global:resourceProperties.Ensure = 'Absent'
+
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = $null
+                            }
+                        }
+                    )
+                }
+            }
+
+            AfterAll {
+                $global:resourceProperties.Ensure = 'Present'
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should call the Connect-VIServer mock with the passed server and credentials once' {
+                # Act
+                $resource.Test()
+
+                # Assert
+                Assert-MockCalled -CommandName Connect-VIServer `
+                    -ParameterFilter { $Server -eq $global:resourceProperties.Server -and $Credential -eq $global:resourceProperties.Credential } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-VMHost with the passed server and name once' {
+                # Act
+                $resource.Get()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-VMHost `
+                    -ParameterFilter { $Server -eq $vCenter -and $Name -eq $global:resourceProperties.Name } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should call Get-View with the passed server and id once' {
+                # Act
+                $resource.Get()
+
+                # Assert
+                Assert-MockCalled -CommandName Get-View `
+                    -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $networkSystemObject } `
+                    -ModuleName $script:moduleName -Exactly 1 -Scope It
+            }
+
+            It 'Should return $true (The VSS does not exist)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $true
+            }
+        }
+
+        Context 'Absent + VSS does exist with different properties' {
+            BeforeAll {
+                $global:resourceProperties.Ensure = 'Absent'
+
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu + 1
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts + 1
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+
+            AfterAll {
+                $global:resourceProperties.Ensure = 'Present'
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should return $false (The VSS exists)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $false
+            }
+        }
+
+        Context 'Absent + VSS does exist with the same properties' {
+            BeforeAll {
+                $global:resourceProperties.Ensure = 'Absent'
+
+                $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+                $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+                $vCenterMock = {
+                    return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+                }
+                $vmHostMock = {
+                    return [VMware.Vim.VMHost] @{
+                        Name = '10.23.82.112'
+                        ExtensionData = [VMware.Vim.HostExtensionData] @{
+                            ConfigManager = [VMware.Vim.HostConfigManager] @{
+                                NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                            }
+                        }
+                    }
+                }
+                $networkSystemMock = {
+                    return (
+                        [VMware.Vim.HostNetworkSystem] @{
+                            NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                                vswitch = @(
+                                    [VMware.Vim.HostVirtualSwitch]@{
+                                        Key = $global:resourceProperties.Key
+                                        Mtu = $global:resourceProperties.Mtu
+                                        Name = $global:resourceProperties.VssName
+                                        NumPorts = $global:resourceProperties.NumPorts
+                                        NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                        Pnic = $global:resourceProperties.Pnic
+                                        PortGroup = $global:resourceProperties.Portgroup
+                                    }
+                                )
+                            }
+                        }
+                    )
+                }
+            }
+
+            AfterAll {
+                $global:resourceProperties.Ensure = 'Present'
+            }
+
+            # Arrange
+            Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+            $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+            It 'Should return $false (The VSS exists)' {
+                # Act
+                $result = $resource.Test()
+
+                # Assert
+                $result | Should -Be $false
+            }
+        }
+    }
+
+    Describe 'VMHostVss\Get' -Tag 'Get' {
+        BeforeAll {
+            $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+            $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+
+            $vCenterMock = {
+                return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'}
+            }
+            $vmHostMock = {
+                return [VMware.Vim.VMHost] @{
+                    Name = '10.23.82.112'
+                    ExtensionData = [VMware.Vim.HostExtensionData] @{
+                        ConfigManager = [VMware.Vim.HostConfigManager] @{
+                            NetworkSystem = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
+                        }
+                    }
+                }
+            }
+            $networkSystemMock = {
+                return (
+                    [VMware.Vim.HostNetworkSystem] @{
+                        NetworkInfo = [VMware.Vim.HostNetworkInfo] @{
+                            vswitch = @(
+                                [VMware.Vim.HostVirtualSwitch]@{
+                                    Key = $global:resourceProperties.Key
+                                    Mtu = $global:resourceProperties.Mtu
+                                    Name = $global:resourceProperties.VssName
+                                    NumPorts = $global:resourceProperties.NumPorts
+                                    NumPortsAvailable = $global:resourceProperties.NumPortsAvailable
+                                    Pnic = $global:resourceProperties.Pnic
+                                    PortGroup = $global:resourceProperties.Portgroup
+                                }
+                            )
+                        }
+                    }
+                )
+            }
+        }
+
+        # Arrange
+        Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
+        Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+        Mock -CommandName Get-View -MockWith $networkSystemMock -ModuleName $script:moduleName
+
+        $resource = New-Object -TypeName $script:resourceName -Property $global:resourceProperties
+
+        It 'Should call the Connect-VIServer mock with the passed server and credentials once' {
+            # Act
+            $resource.Get()
+
+            # Assert
+            Assert-MockCalled -CommandName Connect-VIServer `
+                -ParameterFilter { $Server -eq $global:resourceProperties.Server -and $Credential -eq $global:resourceProperties.Credential } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
+        }
+
+        It 'Should call Get-VMHost with the passed server and name once' {
+            # Act
+            $resource.Get()
+
+            # Assert
+            Assert-MockCalled -CommandName Get-VMHost `
+                -ParameterFilter { $Server -eq $vCenter -and $Name -eq $global:resourceProperties.Name } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
+        }
+
+        It 'Should call Get-View with the passed server and id once' {
+            # Act
+            $resource.Get()
+
+            # Assert
+            Assert-MockCalled -CommandName Get-View `
+                -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $networkSystemObject } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
+        }
+
+        It 'Should match the properties retrieved from the server' {
+            # Act
+            $result = $resource.Get()
+
+            # Assert
+            $result.Server | Should -Be $global:resourceProperties.Server
+            $result.Credential | Should -Be $global:resourceProperties.Credential
+            $result.Name | Should -Be $global:resourceProperties.Name
+            $result.Ensure | Should -Be $global:resourceProperties.Ensure
+            $result.VssName | Should -Be $global:resourceProperties.VssName
+            $result.NumPorts | Should -Be $global:resourceProperties.NumPorts
+            $result.Mtu | Should -Be $global:resourceProperties.Mtu
+            $result.Key | Should -Be $global:resourceProperties.Key
+            $result.NumPortsAvailable | Should -Be $global:resourceProperties.NumPortsAvailable
+            $result.Pnic | Should -Be $global:resourceProperties.Pnic
+            $result.PortGroup | Should -Be $global:resourceProperties.Portgroup
+        }
+    }
+}
+Finally {
+    # Calls the function to Remove the mocked VMware.VimAutomation.Core module after all tests.
+    AfterAllTests
+}

--- a/Source/VMware.vSphereDSC/VMware.vSphereDSC.Helper.psm1
+++ b/Source/VMware.vSphereDSC/VMware.vSphereDSC.Helper.psm1
@@ -230,3 +230,40 @@ function Set-VMHostSyslogConfig {
     $esxcli.system.syslog.config.set.Invoke($VMHostSyslogConfig)
     $esxcli.system.syslog.reload.Invoke()
 }
+
+function New-VssConfig {
+    [CmdletBinding()]
+    [OutputType([VMware.Vim.HostVirtualSwitchConfig])]
+    param(
+        [string]$Name,
+        [int] $NumPorts,
+        [int] $Mtu,
+        [string]$Operation
+    )
+
+    $vssConfig = New-Object VMware.Vim.HostVirtualSwitchConfig
+    $vssConfig.Name = $Name
+    $vssConfig.ChangeOperation = $Operation
+    $vssConfig.Spec = New-Object VMware.Vim.HostVirtualSwitchSpec
+    $vssConfig.Spec.NumPorts = $NumPorts
+    $vssConfig.Spec.Mtu = $Mtu
+
+    return $vssConfig
+}
+
+function Update-Network {
+    [CmdletBinding()]
+    param(
+        [VMware.Vim.HostNetworkSystem] $NetworkSystem,
+        [string]$Type,
+        [VMware.Vim.HostVirtualSwitchConfig] $VssConfig
+    )
+
+    $config = New-Object VMware.Vim.HostNetworkConfig
+    switch ($Type) {
+        'VSS' {
+            $config.Vswitch += $VssConfig
+        }
+    }
+    $NetworkSystem.UpdateNetworkConfig($config, [VMware.Vim.HostConfigChangeMode]::modify)
+}


### PR DESCRIPTION
This PR contains the 1st draft of the VMHostVss resource.
The underlying VSS related subresources are not implemented yet (some skeleton files are present).

The reason is that I first wanted to have some new concepts I introduced validated.

1) Components on a VSS will be organised as separate resources
  a) The VMHostVss resource is the basic resource
  b) Further VSS settings, like Security, Teaming... will be implemented as separate resources
  c) The full collection of the VMHostVss and underlying resources will depend strongly on the DependsOn parameter
2) The resources for a VSS will be organised in a folder structure accordingly
3) I used Global resource properties for Unit testing
  a) This allows me to use these variables in the Mock block (vs hard coding them)
  b) The global variable is removed in the AfterAllTests function, which is called from the Finally block
4) I used a Try-Finally construct for Unit testing. This seems to be the template that MSFT proposes

This PR is **not to be merged** and only intended for feedback on the new concepts.
1st Draft

Signed-off-by: LucD <lucd@lucd.info>