### PR TITLE
Fixes for issue #74 and #75

### DIFF
--- a/Source/VMware.vSphereDSC/DSCResources/VMHostDnsSettings.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostDnsSettings.ps1
@@ -172,7 +172,7 @@ class VMHostDnsSettings : VMHostBaseDSC {
         }
 
         $dnsConfig = New-DNSConfig @dnsConfigArgs
-        $networkSystem = Get-View -Server $this.Connection $vmHost.ExtensionData.ConfigManager.NetworkSystem
+        $networkSystem = Get-View -Server $this.Connection -Id $vmHost.ExtensionData.ConfigManager.NetworkSystem
 
         try {
             Update-DNSConfig -NetworkSystem $networkSystem -DnsConfig $dnsConfig

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNtpSettings.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNtpSettings.ps1
@@ -143,7 +143,7 @@ class VMHostNtpSettings : VMHostBaseDSC {
         }
 
         $dateTimeConfig = New-DateTimeConfig -NtpServer $this.NtpServer
-        $dateTimeSystem = Get-View -Server $this.Connection $vmHost.ExtensionData.ConfigManager.DateTimeSystem
+        $dateTimeSystem = Get-View -Server $this.Connection -Id $vmHost.ExtensionData.ConfigManager.DateTimeSystem
 
         Update-DateTimeConfig -DateTimeSystem $dateTimeSystem -DateTimeConfig $dateTimeConfig
     }
@@ -160,7 +160,7 @@ class VMHostNtpSettings : VMHostBaseDSC {
             return
         }
 
-        $serviceSystem = Get-View -Server $this.Connection $vmHost.ExtensionData.ConfigManager.ServiceSystem
+        $serviceSystem = Get-View -Server $this.Connection -Id $vmHost.ExtensionData.ConfigManager.ServiceSystem
         Update-ServicePolicy -ServiceSystem $serviceSystem -ServiceId $this.ServiceId -ServicePolicyValue $this.NtpServicePolicy.ToString().ToLower()
     }
 }

--- a/Source/VMware.vSphereDSC/DSCResources/vCenterStatistics.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/vCenterStatistics.ps1
@@ -102,7 +102,7 @@ class vCenterStatistics : BaseDSC {
     #>
     [PSObject] GetPerformanceManager() {
         $vCenter = $this.Connection
-        $performanceManager = Get-View -Server $this.Connection $vCenter.ExtensionData.Content.PerfManager
+        $performanceManager = Get-View -Server $this.Connection -Id $vCenter.ExtensionData.Content.PerfManager
 
         return $performanceManager
     }

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
@@ -51,6 +51,28 @@ Add-Type -TypeDefinition @"
         Unset
     }
 
+    public class ManagedObjectReference : System.IEquatable<ManagedObjectReference>
+    {
+        public string Type { get; set; }
+
+        public string Value { get; set; }
+
+        public bool Equals(ManagedObjectReference moRef)
+        {
+            return moRef != null && this.Type == moRef.Type && this.Value == moRef.Value;
+        }
+
+        public override bool Equals(object moRef)
+        {
+            return this.Equals(moRef as ManagedObjectReference);
+        }
+
+        public override int GetHashCode()
+        {
+            return (this.Type + "_" + this.Value).GetHashCode();
+        }
+    }
+
     public class VIServer : System.IEquatable<VIServer>
     {
         public string Name { get; set; }
@@ -312,11 +334,11 @@ Add-Type -TypeDefinition @"
 
     public class HostConfigManager
     {
-        public HostDateTimeSystem DateTimeSystem { get; set; }
+        public ManagedObjectReference DateTimeSystem { get; set; }
 
-        public HostNetworkSystem NetworkSystem { get; set; }
+        public ManagedObjectReference NetworkSystem { get; set; }
 
-        public HostServiceSystem ServiceSystem { get; set; }
+        public ManagedObjectReference ServiceSystem { get; set; }
     }
 
     public class HostExtensionData
@@ -462,7 +484,7 @@ Add-Type -TypeDefinition @"
 
     public class ServiceContent
     {
-        public PerformanceManager PerfManager { get; set; }
+        public ManagedObjectReference PerfManager { get; set; }
     }
 
     public class VCenterExtensionData
@@ -649,9 +671,25 @@ function Get-VMHost {
 }
 
 function Get-View {
+    [CmdletBinding()]
     param(
         [PSObject] $Server,
-        [PSObject] $VIObject
+        [Parameter(ParameterSetName = 'GetViewByVIObject')]
+        [PSObject] $VIObject,
+        [Parameter(ParameterSetName = 'GetView')]
+        [VMware.Vim.ManagedObjectReference] $Id,
+        [Parameter(ParameterSetName = 'GetView')]
+        [Parameter(ParameterSetName = 'GetEntity')]
+        [Parameter(ParameterSetName = 'GetViewByRelatedObject')]
+        [string[]] $Property,
+        [Parameter(ParameterSetName = 'GetEntity')]
+        [string[]] $ViewType,
+        [Parameter(ParameterSetName = 'GetEntity')]
+        [VMware.Vim.ManagedObjectReference[]] $SearchRoot,
+        [Parameter(ParameterSetName = 'GetEntity')]
+        [hashtable] $Filter,
+        [Parameter(ParameterSetName = 'GetViewByRelatedObject')]
+        [PSObject] $RelatedObject
     )
 
     return $null

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostDnsSettings.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostDnsSettings.Unit.Tests.ps1
@@ -182,10 +182,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ ConfigManager = [VMware.Vim.HostConfigManager] @{ NetworkSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' } } } }
             }
             $dnsConfigMock = {
                 return [VMware.Vim.HostDnsConfig] @{ Dhcp = $true; DomainName = 'Domain Name'; HostName = 'Host Name'; VirtualNicDevice = 'VirtualNicDevice' }

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostDnsSettings.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostDnsSettings.Unit.Tests.ps1
@@ -70,7 +70,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ ConfigManager = [VMware.Vim.HostConfigManager] @{ NetworkSystem `
-                     = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' } } } }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' } } } }
             }
             $networkSystemMock = {
                 return [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
@@ -109,6 +109,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
         BeforeAll {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
+            $networkSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' }
             $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
 
             $viServerMock = {
@@ -116,7 +117,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ ConfigManager = [VMware.Vim.HostConfigManager] @{ NetworkSystem `
-                     = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' } } } }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' } } } }
             }
             $dnsConfigMock = {
                 return [VMware.Vim.HostDnsConfig] @{ Dhcp = $false; DomainName = 'Domain Name'; HostName = 'Host Name' }
@@ -154,7 +155,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $networkSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $networkSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -173,6 +174,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
         BeforeAll {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
+            $networkSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' }
             $networkSystemObject = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }
 
             $viServerMock = {
@@ -180,7 +182,10 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ ConfigManager = [VMware.Vim.HostConfigManager] @{ NetworkSystem `
-                     = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' } } } }
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' }
+                        }
+                    }
+                }
             }
             $dnsConfigMock = {
                 return [VMware.Vim.HostDnsConfig] @{ Dhcp = $true; DomainName = 'Domain Name'; HostName = 'Host Name'; VirtualNicDevice = 'VirtualNicDevice' }
@@ -221,7 +226,7 @@ Describe 'VMHostDnsSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $networkSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $networkSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -255,7 +260,7 @@ Describe 'VMHostDnsSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ ConfigManager = [VMware.Vim.HostConfigManager] @{ NetworkSystem `
-                     = [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' } } } }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostNetworkSystem'; Value = 'networkSystem' } } } }
             }
             $networkSystemMock = {
                 return [VMware.Vim.HostNetworkSystem] @{ Id = 'HostNetworkSystem' }

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNtpSettings.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNtpSettings.Unit.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
             Mock -CommandName New-DateTimeConfig -MockWith $dateTimeConfigMock -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $dateTimeSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemObject } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-DateTimeConfig -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -145,7 +145,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemObject } `
                               -ModuleName $script:moduleName -Exactly 0 -Scope It
         }
 
@@ -166,6 +166,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $dateTimeInfoObject = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } }
+            $dateTimeSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
             $dateTimeSystemObject = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' }
 
             $viServerMock = {
@@ -175,7 +176,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } }
@@ -191,7 +192,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName New-DateTimeConfig -MockWith $dateTimeConfigMock `
                                                  -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $dateTimeSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-DateTimeConfig -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -215,7 +216,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -236,6 +237,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $dateTimeInfoObject = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('1.bg.pool.ntp.org') } }
+            $dateTimeSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
             $dateTimeSystemObject = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' }
 
             $viServerMock = {
@@ -245,7 +247,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('1.bg.pool.ntp.org') } }
@@ -261,7 +263,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName New-DateTimeConfig -MockWith $dateTimeConfigMock `
                                                  -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $dateTimeSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-DateTimeConfig -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -285,7 +287,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -306,6 +308,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $dateTimeInfoObject = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('1.bg.pool.ntp.org') } }
+            $dateTimeSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
             $dateTimeSystemObject = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' }
 
             $viServerMock = {
@@ -315,7 +318,10 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('1.bg.pool.ntp.org') } }
@@ -331,7 +337,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName New-DateTimeConfig -MockWith $dateTimeConfigMock `
                                                  -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $dateTimeSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-DateTimeConfig -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -355,7 +361,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -377,6 +383,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $dateTimeInfoObject = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                                 = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } }
+            $dateTimeSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
             $dateTimeSystemObject = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' }
 
             $viServerMock = {
@@ -386,7 +393,10 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } }
@@ -402,7 +412,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName New-DateTimeConfig -MockWith $dateTimeConfigMock `
                                                  -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $dateTimeSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-DateTimeConfig -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -426,7 +436,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $dateTimeSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $dateTimeSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 0 -Scope It
         }
 
@@ -447,6 +457,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $serviceSystemObject = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
+            $serviceSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' }
 
             $viServerMock = {
                 return [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
@@ -455,7 +466,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
                      = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
             $serviceSystemMock = {
                 return [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
@@ -478,7 +489,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $serviceSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $serviceSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 0 -Scope It
         }
 
@@ -500,6 +511,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $serviceSystemObject = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
+            $serviceSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' }
 
             $viServerMock = {
                 return [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
@@ -508,7 +520,9 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
                      = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
+                    }
+                }
             }
             $serviceSystemMock = {
                 return [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
@@ -533,7 +547,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $serviceSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $serviceSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 0 -Scope It
         }
 
@@ -555,6 +569,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             # Arrange
             $viServer = [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
             $serviceSystemObject = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
+            $serviceSystemMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' }
 
             $viServerMock = {
                 return [VMware.Vim.VIServer] @{ Name = '10.23.82.112'; User = 'user' }
@@ -563,7 +578,9 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
                      = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
+                    }
+                }
             }
             $serviceSystemMock = {
                 return [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
@@ -574,7 +591,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
             Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
             Mock -CommandName Get-View -MockWith $serviceSystemMock `
-                                       -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $serviceSystemObject } `
+                                       -ParameterFilter { $Server -eq $viServer -and $Id -eq $serviceSystemMoRef } `
                                        -ModuleName $script:moduleName
             Mock -CommandName Update-ServicePolicy -MockWith { return $null } -ModuleName $script:moduleName
         }
@@ -588,7 +605,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $viServer -and $VIObject -eq $serviceSystemObject } `
+                              -ParameterFilter { $Server -eq $viServer -and $Id -eq $serviceSystemMoRef } `
                               -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
@@ -622,7 +639,10 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo `
-                     = [VMware.Vim.HostDateTimeConfig] @{ NtpConfig = [VMware.Vim.HostNtpConfig] @{} } } } }
+                                = [VMware.Vim.HostDateTimeConfig] @{ NtpConfig = [VMware.Vim.HostNtpConfig] @{} }
+                        }
+                    }
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -638,8 +658,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call Get-VMHost mock with the passed server and name once' {
@@ -648,8 +668,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Get-VMHost `
-                              -ParameterFilter { $Server -eq $viServer -and $Name -eq $script:resourceProperties.Name } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $viServer -and $Name -eq $script:resourceProperties.Name } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 
@@ -661,7 +681,10 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo `
-                     = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{} } } } }
+                                = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{} }
+                        }
+                    }
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -687,9 +710,14 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') }
+                            }
+                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
 
             $script:resourceProperties.NtpServer = @()
@@ -717,9 +745,14 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') }
+                            }
+                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org')
@@ -747,9 +780,14 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') }
+                            }
+                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org')
@@ -777,9 +815,14 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                     = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') }
+                            }
+                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
+                        }
+                    }
+                }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org', '0.bg.pool.ntp.org')
@@ -808,8 +851,10 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
-                     = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
+                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
+                    }
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -836,8 +881,10 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
-                     = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
+                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
+                    }
+                }
             }
 
             $script:resourceProperties.NtpServicePolicy = 'automatic'
@@ -866,26 +913,28 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
-                     = [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' } } } }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
+                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
+                    }
+                }
             }
 
-            $script:resourceProperties.NtpServicePolicy = 'on'
+                $script:resourceProperties.NtpServicePolicy = 'on'
 
-            Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
-            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
-        }
+                Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
+                Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+            }
 
-        # Arrange
-        $resource = New-Object -TypeName $script:resourceName -Property $script:resourceProperties
+            # Arrange
+            $resource = New-Object -TypeName $script:resourceName -Property $script:resourceProperties
 
-        It 'Should return $false (The desired NTP Service Policy is different than the current NTP Service Policy)' {
-            # Act
-            $result = $resource.Test()
+            It 'Should return $false (The desired NTP Service Policy is different than the current NTP Service Policy)' {
+                # Act
+                $result = $resource.Test()
 
-            # Assert
-            $result | Should -Be $false
-        }
+                # Assert
+                $result | Should -Be $false
+            }
     }
 }
 
@@ -902,7 +951,7 @@ Describe 'VMHostNtpSettings\Get' -Tag 'Get' {
                  = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                  = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } }; Service = [VMware.Vim.HostServiceInfo] @{ Service `
                  = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                 = [VMware.Vim.HostDateTimeSystem] @{ Id = 'HostDateTimeSystem' } } } }
+                 = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
         }
 
         Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNtpSettings.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNtpSettings.Unit.Tests.ps1
@@ -318,10 +318,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('1.bg.pool.ntp.org') } }
@@ -393,10 +390,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
                      = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
             $dateTimeConfigMock = {
                 return [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } }
@@ -520,9 +514,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
                      = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
-                    }
-                }
+                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
             $serviceSystemMock = {
                 return [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
@@ -578,9 +570,7 @@ Describe 'VMHostNtpSettings\Set' -Tag 'Set' {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
                      = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
-                    }
-                }
+                     = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
             $serviceSystemMock = {
                 return [VMware.Vim.HostServiceSystem] @{ Id = 'HostServiceSystem' }
@@ -639,10 +629,7 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo `
-                                = [VMware.Vim.HostDateTimeConfig] @{ NtpConfig = [VMware.Vim.HostNtpConfig] @{} }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostDateTimeConfig] @{ NtpConfig = [VMware.Vim.HostNtpConfig] @{} } } } }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -658,8 +645,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call Get-VMHost mock with the passed server and name once' {
@@ -668,8 +655,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Get-VMHost `
-                -ParameterFilter { $Server -eq $viServer -and $Name -eq $script:resourceProperties.Name } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $viServer -and $Name -eq $script:resourceProperties.Name } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 
@@ -681,10 +668,7 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo `
-                                = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{} }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig = [VMware.Vim.HostNtpConfig] @{} } } } }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -710,14 +694,9 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') }
-                            }
-                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
 
             $script:resourceProperties.NtpServer = @()
@@ -745,14 +724,9 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') }
-                            }
-                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org')
@@ -780,14 +754,9 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') }
-                            }
-                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org')
@@ -815,14 +784,9 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             }
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
-                        = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
-                                    = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') }
-                            }
-                        }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
-                                = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' }
-                        }
-                    }
-                }
+                     = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig'; NtpConfig `
+                     = [VMware.Vim.HostNtpConfig] @{ Server = @('0.bg.pool.ntp.org', '1.bg.pool.ntp.org') } } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ DateTimeSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostDateTimeSystem'; Value = 'DateTimeSystem' } } } }
             }
 
             $script:resourceProperties.NtpServer = @('1.bg.pool.ntp.org', '0.bg.pool.ntp.org')
@@ -851,10 +815,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
-                    }
-                }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
@@ -881,10 +843,8 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
-                    }
-                }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
 
             $script:resourceProperties.NtpServicePolicy = 'automatic'
@@ -913,28 +873,26 @@ Describe 'VMHostNtpSettings\Test' -Tag 'Test' {
             $vmHostMock = {
                 return [VMware.Vim.VMHost] @{ ExtensionData `
                      = [VMware.Vim.HostExtensionData] @{ Config = [VMware.Vim.HostConfig] @{ DateTimeInfo = [VMware.Vim.HostDateTimeConfig] @{ Id = 'HostDateTimeConfig' }; Service `
-                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager `
-                            = [VMware.Vim.HostConfigManager] @{ ServiceSystem = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } }
-                    }
-                }
+                     = [VMware.Vim.HostServiceInfo] @{ Service = @([VMware.Vim.HostService] @{ Key = 'ntpd'; Policy = 'automatic' }) } }; ConfigManager = [VMware.Vim.HostConfigManager] @{ ServiceSystem `
+                     = [VMware.Vim.ManagedObjectReference] @{ Type = 'HostServiceSystem'; Value = 'ServiceSystem' } } } }
             }
 
-                $script:resourceProperties.NtpServicePolicy = 'on'
+            $script:resourceProperties.NtpServicePolicy = 'on'
 
-                Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
-                Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
-            }
+            Mock -CommandName Connect-VIServer -MockWith $viServerMock -ModuleName $script:moduleName
+            Mock -CommandName Get-VMHost -MockWith $vmHostMock -ModuleName $script:moduleName
+        }
 
-            # Arrange
-            $resource = New-Object -TypeName $script:resourceName -Property $script:resourceProperties
+        # Arrange
+        $resource = New-Object -TypeName $script:resourceName -Property $script:resourceProperties
 
-            It 'Should return $false (The desired NTP Service Policy is different than the current NTP Service Policy)' {
-                # Act
-                $result = $resource.Test()
+        It 'Should return $false (The desired NTP Service Policy is different than the current NTP Service Policy)' {
+            # Act
+            $result = $resource.Test()
 
-                # Assert
-                $result | Should -Be $false
-            }
+            # Assert
+            $result | Should -Be $false
+        }
     }
 }
 

--- a/Source/VMware.vSphereDSC/Tests/Unit/vCenterStatistics.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/vCenterStatistics.Unit.Tests.ps1
@@ -62,18 +62,24 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
     Context 'Invoking with default resource properties' {
         BeforeAll {
             $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+            $perfManagerMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
             $perfManager = [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' }
             $perfInterval = [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; SamplingPeriod = 600; Length = 2629800; Level = 1 }
 
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
             $performanceIntervalMock = {
                 return [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; SamplingPeriod = 600; Length = 2629800; Level = 1 }
@@ -94,8 +100,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -104,8 +110,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $perfManager } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the New-PerformanceInterval mock with the Performance Interval once' {
@@ -114,9 +120,9 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName New-PerformanceInterval `
-                              -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
-                                                 $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
+                    $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Update-PerfInterval mock with the Performance Manager and Performance Interval once' {
@@ -125,8 +131,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Update-PerfInterval `
-                              -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 
@@ -138,18 +144,24 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
             $script:resourceProperties.IntervalMinutes = 30
 
             $perfInterval = [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $true; `
-                                                         SamplingPeriod = 30 * 60; Length = 2 * 2629800; `
-                                                         Level = 2 }
+                    SamplingPeriod = 30 * 60; Length = 2 * 2629800; `
+                    Level = 2
+            }
 
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
             $performanceIntervalMock = {
                 return [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $true; SamplingPeriod = 30 * 60; Length = 2 * 2629800; Level = 2 }
@@ -170,9 +182,9 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName New-PerformanceInterval `
-                              -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
-                                                 $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
+                    $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Update-PerfInterval mock with the Performance Manager and Performance Interval once' {
@@ -181,8 +193,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Update-PerfInterval `
-                              -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 }
@@ -198,17 +210,23 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
     Context 'Invoking with default resource properties' {
         BeforeAll {
             $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+            $perfManagerMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
             $perfManager = [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' }
 
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -224,8 +242,8 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -234,8 +252,8 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                              -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $perfManager } `
-                              -ModuleName $script:moduleName -Exactly 1 -Scope It
+                -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+                -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should return $true (The Statistics Settings are in the desired state)' {
@@ -257,12 +275,17 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -291,12 +314,17 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -325,12 +353,17 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -359,12 +392,17 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -393,12 +431,17 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                        }
+                    }
+                }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                                SamplingPeriod = 600; Length = 2629800; Level = 1
+                        })
+                }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -428,18 +471,24 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
 
     BeforeAll {
         $vCenter = [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user' }
+        $perfManagerMoRef = [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
         $perfManager = [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' }
         $perfInterval = [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; SamplingPeriod = 600; Length = 2629800; Level = 1 }
 
         # Arrange
         $vCenterMock = {
             return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-            [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-            [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id' } } } }
+                    [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                            [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
+                    }
+                }
+            }
         }
         $performanceManagerMock = {
             return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                                      SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
+                            SamplingPeriod = 600; Length = 2629800; Level = 1
+                    })
+            }
         }
 
         Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -455,8 +504,8 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
 
         # Assert
         Assert-MockCalled -CommandName Connect-VIServer `
-                          -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                          -ModuleName $script:moduleName -Exactly 1 -Scope It
+            -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+            -ModuleName $script:moduleName -Exactly 1 -Scope It
     }
 
     It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -465,8 +514,8 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
 
         # Assert
         Assert-MockCalled -CommandName Get-View `
-                          -ParameterFilter { $Server -eq $vCenter -and $VIObject -eq $perfManager } `
-                          -ModuleName $script:moduleName -Exactly 1 -Scope It
+            -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+            -ModuleName $script:moduleName -Exactly 1 -Scope It
     }
 
     It 'Should return the Resource with the properties retrieved from the server' {

--- a/Source/VMware.vSphereDSC/Tests/Unit/vCenterStatistics.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/vCenterStatistics.Unit.Tests.ps1
@@ -69,17 +69,12 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
             $performanceIntervalMock = {
                 return [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; SamplingPeriod = 600; Length = 2629800; Level = 1 }
@@ -100,8 +95,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -110,8 +105,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the New-PerformanceInterval mock with the Performance Interval once' {
@@ -120,9 +115,9 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName New-PerformanceInterval `
-                -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
-                    $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
+                                                 $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Update-PerfInterval mock with the Performance Manager and Performance Interval once' {
@@ -131,8 +126,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Update-PerfInterval `
-                -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 
@@ -144,24 +139,18 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
             $script:resourceProperties.IntervalMinutes = 30
 
             $perfInterval = [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $true; `
-                    SamplingPeriod = 30 * 60; Length = 2 * 2629800; `
-                    Level = 2
-            }
+                                                         SamplingPeriod = 30 * 60; Length = 2 * 2629800; `
+                                                         Level = 2 }
 
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
             $performanceIntervalMock = {
                 return [VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $true; SamplingPeriod = 30 * 60; Length = 2 * 2629800; Level = 2 }
@@ -182,9 +171,9 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName New-PerformanceInterval `
-                -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
-                    $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Key -eq $perfInterval.Key -and $Name -eq $perfInterval.Name -and $Enabled -eq $perfInterval.Enabled -and `
+                                                 $SamplingPeriod -eq $perfInterval.SamplingPeriod -and $Length -eq $perfInterval.Length -and $Level -eq $perfInterval.Level } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Update-PerfInterval mock with the Performance Manager and Performance Interval once' {
@@ -193,8 +182,8 @@ Describe 'vCenterStatistics\Set' -Tag 'Set' {
 
             # Assert
             Assert-MockCalled -CommandName Update-PerfInterval `
-                -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $PerformanceManager -eq $perfManager -and $PerformanceInterval -eq $perfInterval } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
     }
 }
@@ -216,17 +205,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -242,8 +226,8 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Connect-VIServer `
-                -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -252,8 +236,8 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
 
             # Assert
             Assert-MockCalled -CommandName Get-View `
-                -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
-                -ModuleName $script:moduleName -Exactly 1 -Scope It
+                              -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+                              -ModuleName $script:moduleName -Exactly 1 -Scope It
         }
 
         It 'Should return $true (The Statistics Settings are in the desired state)' {
@@ -275,17 +259,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -314,17 +293,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -353,17 +327,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -392,17 +361,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -431,17 +395,12 @@ Describe 'vCenterStatistics\Test' -Tag 'Test' {
             # Arrange
             $vCenterMock = {
                 return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                        [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                        }
-                    }
-                }
+                [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+                [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
             }
             $performanceManagerMock = {
                 return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                                SamplingPeriod = 600; Length = 2629800; Level = 1
-                        })
-                }
+                                                          SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
             }
 
             Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -478,17 +437,12 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
         # Arrange
         $vCenterMock = {
             return [VMware.Vim.VCenter] @{ Name = '10.23.82.112'; User = 'user'; ExtensionData = `
-                    [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
-                            [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' }
-                    }
-                }
-            }
+            [VMware.Vim.VCenterExtensionData] @{ Content = [VMware.Vim.ServiceContent] @{ PerfManager = `
+            [VMware.Vim.ManagedObjectReference] @{ Type = 'PerformanceManager'; Value = 'PerfMgr' } } } }
         }
         $performanceManagerMock = {
             return [VMware.Vim.PerformanceManager] @{ Id = 'PerfManager Id'; HistoricalInterval = @([VMware.Vim.PerfInterval] @{ Key = 1; Name = 'Month'; Enabled = $false; `
-                            SamplingPeriod = 600; Length = 2629800; Level = 1
-                    })
-            }
+                                                      SamplingPeriod = 600; Length = 2629800; Level = 1 }) }
         }
 
         Mock -CommandName Connect-VIServer -MockWith $vCenterMock -ModuleName $script:moduleName
@@ -504,8 +458,8 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
 
         # Assert
         Assert-MockCalled -CommandName Connect-VIServer `
-            -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
-            -ModuleName $script:moduleName -Exactly 1 -Scope It
+                          -ParameterFilter { $Server -eq $script:resourceProperties.Server -and $Credential -eq $script:resourceProperties.Credential } `
+                          -ModuleName $script:moduleName -Exactly 1 -Scope It
     }
 
     It 'Should call the Get-View mock with the PerformanceManager once' {
@@ -514,8 +468,8 @@ Describe 'vCenterStatistics\Get' -Tag 'Get' {
 
         # Assert
         Assert-MockCalled -CommandName Get-View `
-            -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
-            -ModuleName $script:moduleName -Exactly 1 -Scope It
+                          -ParameterFilter { $Server -eq $vCenter -and $Id -eq $perfManagerMoRef } `
+                          -ModuleName $script:moduleName -Exactly 1 -Scope It
     }
 
     It 'Should return the Resource with the properties retrieved from the server' {


### PR DESCRIPTION
 #74 Added class definition for ManagedObjectReference
     HostConfigManager now contains ManagedObjectReference entries

 #75 The Get-View function in the TestHelpers module VMware.VimAutomation.Core now supports all parametersets

Signed-off-by: Luc Dekens <dekens.luc@gmail.com>