### PR TITLE
Change VssName property from 'Mandatory' to 'Key' in Documentation

### DIFF
--- a/Documentation/DSCResources/VMHostVss/VMHostVss.md
+++ b/Documentation/DSCResources/VMHostVss/VMHostVss.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the VSS should be Present or Absent. | Present, Absent |
-| **VssName** | Mandatory | string | The name of the VSS. ||
+| **VssName** | Key | string | The name of the VSS. ||
 | **Mtu** | Optional | int | The maximum transmission unit (MTU) associated with this virtual switch in bytes. ||
 
 ## Description

--- a/Documentation/DSCResources/VMHostVssBridge/VMHostVssBridge.md
+++ b/Documentation/DSCResources/VMHostVssBridge/VMHostVssBridge.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the VSS should be Present or Absent. | Present, Absent |
-| **VssName** | Mandatory | string | The name of the VSS. ||
+| **VssName** | Key | string | The name of the VSS. ||
 | **NicDevice** | Optional | string[] | The list of keys of the physical network adapters to be bridged. ||
 | **BeaconInterval** | Optional | int | Determines how often, in seconds, a beacon should be sent. ||
 | **LinkDiscoveryProtocolType** | Optional | string | The discovery protocol type. VSS only supports CDP. | CDP |

--- a/Documentation/DSCResources/VMHostVssSecurity/VMHostVssSecurity.md
+++ b/Documentation/DSCResources/VMHostVssSecurity/VMHostVssSecurity.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the VSS should be Present or Absent. | Present, Absent |
-| **VssName** | Mandatory | string | The name of the VSS. ||
+| **VssName** | Key | string | The name of the VSS. ||
 | **AllowPromiscuous** | Optional | boolean | The flag to indicate whether or not all traffic is seen on the port. ||
 | **ForgedTransmits** | Optional | boolean | The flag to indicate whether or not the virtual network adapter should be allowed to send network traffic with a different MAC address. ||
 | **MacChanges** | Optional | boolean | The flag to indicate whether or not the Media Access Control (MAC) address can be changed. ||

--- a/Documentation/DSCResources/VMHostVssShaping/VMHostVssShaping.md
+++ b/Documentation/DSCResources/VMHostVssShaping/VMHostVssShaping.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the VSS should be Present or Absent. | Present, Absent |
-| **VssName** | Mandatory | string | The name of the VSS. ||
+| **VssName** | Key | string | The name of the VSS. ||
 | **AverageBandwidth** | Optional | long | The average bandwidth in bits per second if shaping is enabled on the port. ||
 | **BurstSize** | Optional | long | The maximum burst size allowed in bytes if shaping is enabled on the port. ||
 | **Enabled** | Optional | boolean | The flag to indicate whether or not traffic shaper is enabled on the port. ||

--- a/Documentation/DSCResources/VMHostVssTeaming/VMHostVssTeaming.md
+++ b/Documentation/DSCResources/VMHostVssTeaming/VMHostVssTeaming.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the VSS should be Present or Absent. | Present, Absent |
-| **VssName** | Mandatory | string | The name of the VSS. ||
+| **VssName** | Key | string | The name of the VSS. ||
 | **CheckBeacon** | Optional | Boolean | The flag to indicate whether or not to enable beacon probing as a method to validate the link status of a physical network adapter. ||
 | **ActiveNic** | Optional | string[] | List of active network adapters used for load balancing. ||
 | **StandbyNic** | Optional | string[] | Standby network adapters used for failover. ||


### PR DESCRIPTION
### Changed
- The VssName property was changed from 'Mandatory' to 'Key' in the Standard Switch Resources Documentation.
