### PR TITLE
Change Key property of VMHostService Resource from 'Mandatory' to 'Key'

### DIFF
--- a/Documentation/DSCResources/VMHostService/VMHostService.md
+++ b/Documentation/DSCResources/VMHostService/VMHostService.md
@@ -7,7 +7,7 @@
 | **Server** | Key | string | Name of the Server we are trying to connect to. The Server can be a vCenter or ESXi. ||
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
-| **Key** | Mandatory | string | The key value of the service. ||
+| **Key** | Key | string | The key value of the service. ||
 | **Policy** | Optional | ServicePolicy | The state of the service after a VMHost reboot. |Unset, On, Off, Automatic|
 | **Running** | Optional | bool | The current state of the service. ||
 

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostService.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostService.ps1
@@ -21,7 +21,7 @@ class VMHostService : VMHostBaseDSC {
 
     The key value of the service.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty(Key)]
     [string] $Key
 
     <#


### PR DESCRIPTION
### Changed
- The Key property was changed from 'Mandatory' to 'Key' for VMHostService Resource.
