### PR TITLE
Change RuleName property of VMHostSatpClaimRule Resource from 'Mandatory' to 'Key'

### DIFF
--- a/Documentation/DSCResources/VMHostSatpClaimRule/VMHostSatpClaimRule.md
+++ b/Documentation/DSCResources/VMHostSatpClaimRule/VMHostSatpClaimRule.md
@@ -8,7 +8,7 @@
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the SATP Claim Rule should be Present or Absent. |Present, Absent|
-| **RuleName** | Mandatory | string | Name of the SATP Claim Rule. ||
+| **RuleName** | Key | string | Name of the SATP Claim Rule. ||
 | **PSPOptions** | Optional | string | PSP options for the SATP Claim Rule. ||
 | **Transport** | Optional | string | Transport Property of the Satp Claim Rule. ||
 | **Description** | Optional | string | Description string to set when adding the SATP Claim Rule. ||

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostSatpClaimRule.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostSatpClaimRule.ps1
@@ -29,7 +29,7 @@ class VMHostSatpClaimRule : VMHostBaseDSC {
 
     Name of the SATP Claim Rule.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty(Key)]
     [string] $RuleName
 
     <#


### PR DESCRIPTION
### Changed
- The RuleName property was changed from 'Mandatory' to 'Key' for VMHostSatpClaimRule Resource.
