### PR TITLE
Change Id property of VMHostAccount Resource from 'Mandatory' to 'Key'

### DIFF
--- a/Documentation/DSCResources/VMHostAccount/VMHostAccount.md
+++ b/Documentation/DSCResources/VMHostAccount/VMHostAccount.md
@@ -6,7 +6,7 @@
 | --- | --- | --- | --- | --- |
 | **Server** | Key | string | Name of the Server we are trying to connect to. The Server can only be ESXi. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
-| **Id** | Mandatory | string | Specifies the ID for the host account. ||
+| **Id** | Key | string | Specifies the ID for the host account. ||
 | **Ensure** | Mandatory | Ensure | Value indicating if the Resource should be Present or Absent. |Present, Absent|
 | **Role** | Mandatory | string | Permission on the VMHost entity is created for the specified User Id with the specified Role. ||
 | **AccountPassword** | Optional | string | Specifies the Password for the host account. ||

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostAccount.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostAccount.ps1
@@ -21,7 +21,7 @@ class VMHostAccount : BaseDSC {
 
     Specifies the ID for the host account.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty(Key)]
     [string] $Id
 
     <#


### PR DESCRIPTION
### Changed
- The Id property was changed from 'Mandatory' to 'Key' for VMHostAccount Resource.
