### PR TITLE
VMHostVssMigration DSC Resource

### DIFF
--- a/Documentation/DSCResources/VDPortGroup/VDPortGroup.md
+++ b/Documentation/DSCResources/VDPortGroup/VDPortGroup.md
@@ -15,6 +15,7 @@
 | **ReferenceVDPortGroupName** | Optional | string | The name for the reference Distributed Port Group. The properties of the new Distributed Port Group will be cloned from the reference Distributed Port Group. ||
 
 ## Description
+
 The resource is used to create, modify the configuration or remove the specified Distributed Port Group.
 
 ## Examples

--- a/Documentation/DSCResources/VDSwitchVMHost/VDSwitchVMHost.md
+++ b/Documentation/DSCResources/VDSwitchVMHost/VDSwitchVMHost.md
@@ -11,6 +11,7 @@
 | **Ensure** | Mandatory | Ensure | Value indicating if the VMHosts should be Present/Absent to/from the specified vSphere Distributed Switch. | Present, Absent |
 
 ## Description
+
 The resource is used to add/remove VMHosts to/from the specified vSphere Distributed Switch.
 
 ## Examples

--- a/Documentation/DSCResources/VMHostVssMigration/VMHostVssMigration.md
+++ b/Documentation/DSCResources/VMHostVssMigration/VMHostVssMigration.md
@@ -1,0 +1,95 @@
+# VMHostVssMigration
+
+## Parameters
+
+| Parameter | Attribute | DataType | Description | Allowed Values |
+| --- | --- | --- | --- | --- |
+| **Server** | Key | string | The name of the Server we are trying to connect to. The Server can only be a vCenter. ||
+| **Credential** | Mandatory | PSCredential | The credentials needed for connection to the specified Server. ||
+| **VMHostName** | Key | string | The name of the VMHost which is going to be used. ||
+| **VssName** | Key | string | The name of the Standard Switch to which the passed Physical Network Adapters, VMKernel Network Adapters and Port Groups should be part of. ||
+| **PhysicalNicNames** | Mandatory | string[] | The names of the Physical Network Adapters that should be part of the Standard Switch. ||
+| **VMKernelNicNames** | Optional | string[] | The names of the VMKernel Network Adapters that should be part of the Standard Switch. ||
+| **PortGroupNames** | Optional | string[] | The names of the Port Groups to which the specified VMKernel Network Adapters should be attached. Accepts the same number of Port Groups as the number of VMKernel Network Adapters specified. The first Adapter is attached to the first Port Group, the second Adapter to the second Port Group, and so on. ||
+
+## Description
+
+The resource is used to migrate Physical Network Adapters and VMKernel Network Adapters attached to the specified Port Groups to the specified Standard Switch. If the specified Port Groups are not present on the Standard Switch, they are created before performing the migration process.
+
+## Examples
+
+### Example 1
+
+Migrates Physical Network Adapters **vmnic0** and **vmnic1** to Standard Switch **MyStandardSwitch**.
+
+```powershell
+Configuration VMHostVssMigration_MigratePhysicalNics_Config {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Server,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $VMHostName
+    )
+
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVssMigration VMHostVssMigration {
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $VMHostName
+            VssName = 'MyStandardSwitch'
+            PhysicalNicNames = @('vmnic0', 'vmnic1')
+        }
+    }
+}
+```
+
+### Example 2
+
+Migrates Physical Network Adapters **vmnic0** and **vmnic1** to Standard Switch **MyStandardSwitch**. Migrates VMKernel Network Adapters **vmk0** and **vmk1** to Standard Switch **MyStandardSwitch** and attaches them to Port Groups **Management Network** and **VM Network** respectively.
+
+```powershell
+Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Server,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $VMHostName
+    )
+
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVssMigration VMHostVssMigration {
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $VMHostName
+            VssName = 'MyStandardSwitch'
+            PhysicalNicNames = @('vmnic0', 'vmnic1')
+            VMKernelNicNames = @('vmk0', 'vmk1')
+            PortGroupNames = @('Management Network', 'VM Network')
+        }
+    }
+}
+```

--- a/Documentation/DSCResources/VMHostVssMigration/VMHostVssMigration.md
+++ b/Documentation/DSCResources/VMHostVssMigration/VMHostVssMigration.md
@@ -60,7 +60,7 @@ Configuration VMHostVssMigration_MigratePhysicalNics_Config {
 Migrates Physical Network Adapters **vmnic0** and **vmnic1** to Standard Switch **MyStandardSwitch**. Migrates VMKernel Network Adapters **vmk0** and **vmk1** to Standard Switch **MyStandardSwitch** and attaches them to Port Groups **Management Network** and **VM Network** respectively.
 
 ```powershell
-Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
+Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNicsWithPortGroups_Config {
     Param(
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -89,6 +89,44 @@ Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
             PhysicalNicNames = @('vmnic0', 'vmnic1')
             VMKernelNicNames = @('vmk0', 'vmk1')
             PortGroupNames = @('Management Network', 'VM Network')
+        }
+    }
+}
+```
+
+### Example 3
+
+Migrates Physical Network Adapters **vmnic0** and **vmnic1** to Standard Switch **MyStandardSwitch**. Migrates VMKernel Network Adapters **vmk0** and **vmk1** to Standard Switch **MyStandardSwitch**. The VMKernel Network Adapters are attached to newly created Port Groups which name has the **VMKernel** prefix.
+
+```powershell
+Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
+    Param(
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Server,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $VMHostName
+    )
+
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node localhost {
+        VMHostVssMigration VMHostVssMigration {
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $VMHostName
+            VssName = 'MyStandardSwitch'
+            PhysicalNicNames = @('vmnic0', 'vmnic1')
+            VMKernelNicNames = @('vmk0', 'vmk1')
         }
     }
 }

--- a/Documentation/DSCResources/VMHostVssNic/VMHostVssNic.md
+++ b/Documentation/DSCResources/VMHostVssNic/VMHostVssNic.md
@@ -25,6 +25,7 @@
 | **VsanTrafficEnabled** | Optional | bool | Indicates that Virtual SAN traffic is enabled on this VMKernel Network Adapter. ||
 
 ## Description
+
 The resource is used to create, update and remove VMKernel Network Adapters added to the specified Standard Switch and Port Group. If the Port Group is not existing, it will be created and the VMKernel Network Adapter will be connected to it.
 
 ## Examples

--- a/Source/VMware.vSphereDSC/Classes/VMHostNetworkMigrationBaseDSC.ps1
+++ b/Source/VMware.vSphereDSC/Classes/VMHostNetworkMigrationBaseDSC.ps1
@@ -1,0 +1,90 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+class VMHostNetworkMigrationBaseDSC : VMHostEntityBaseDSC {
+    <#
+    .DESCRIPTION
+
+    Specifies the names of the Physical Network Adapters that should be part of the vSphere Distributed/Standard Switch.
+    #>
+    [DscProperty(Mandatory)]
+    [string[]] $PhysicalNicNames
+
+    <#
+    .DESCRIPTION
+
+    Specifies the names of the VMKernel Network Adapters that should be part of the vSphere Distributed/Standard Switch.
+    #>
+    [DscProperty()]
+    [string[]] $VMKernelNicNames
+
+    <#
+    .DESCRIPTION
+
+    Retrieves the Physical Network Adapters with the specified names from the server if they exist.
+    For every Physical Network Adapter that does not exist, a warning message is shown to the user without throwing an exception.
+    #>
+    [array] GetPhysicalNetworkAdapters() {
+        $physicalNetworkAdapters = @()
+
+        foreach ($physicalNetworkAdapterName in $this.PhysicalNicNames) {
+            $physicalNetworkAdapter = Get-VMHostNetworkAdapter -Server $this.Connection -Name $physicalNetworkAdapterName -VMHost $this.VMHost -Physical -ErrorAction SilentlyContinue
+            if ($null -eq $physicalNetworkAdapter) {
+                Write-WarningLog -Message "The passed Physical Network Adapter {0} was not found and it will be ignored." -Arguments @($physicalNetworkAdapterName)
+            }
+            else {
+                $physicalNetworkAdapters += $physicalNetworkAdapter
+            }
+        }
+
+        return $physicalNetworkAdapters
+    }
+
+    <#
+    .DESCRIPTION
+
+    Retrieves the VMKernel Network Adapters with the specified names from the server if they exist.
+    If one of the passed VMKernel Network Adapters does not exist, an exception is thrown.
+    #>
+    [array] GetVMKernelNetworkAdapters() {
+        $vmKernelNetworkAdapters = @()
+
+        foreach ($vmKernelNetworkAdapterName in $this.VMKernelNicNames) {
+            $getVMHostNetworkAdapterParams = @{
+                Server = $this.Connection
+                Name = $vmKernelNetworkAdapterName
+                VMHost = $this.VMHost
+                VMKernel = $true
+                ErrorAction = 'Stop'
+            }
+
+            try {
+                $vmKernelNetworkAdapter = Get-VMHostNetworkAdapter @getVMHostNetworkAdapterParams
+                $vmKernelNetworkAdapters += $vmKernelNetworkAdapter
+            }
+            catch {
+                <#
+                Here 'throw' should be used instead of 'Write-WarningLog' because if we ignore one VMKernel Network Adapter that is invalid, the mapping between VMKernel
+                Network Adapters and Port Groups will not work: The first Adapter should be attached to the first Port Group,
+                the second Adapter should be attached to the second Port Group, and so on.
+                #>
+                throw "The passed VMKernel Network Adapter $($vmKernelNetworkAdapterName) was not found."
+            }
+        }
+
+        return $vmKernelNetworkAdapters
+    }
+}

--- a/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNicsAndVMKernelNicsWithPortGroups_Config.ps1
+++ b/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNicsAndVMKernelNicsWithPortGroups_Config.ps1
@@ -54,10 +54,10 @@ $script:configurationData = @{
 .DESCRIPTION
 
 Migrates Physical Network Adapters 'vmnic0' and 'vmnic1' to Standard Switch 'MyStandardSwitch'.
-Migrates VMKernel Network Adapters 'vmk0' and 'vmk1' to Standard Switch 'MyStandardSwitch'. The VMKernel Network Adapters are attached to newly created
-Port Groups which name has the 'VMKernel' prefix.
+Migrates VMKernel Network Adapters 'vmk0' and 'vmk1' to Standard Switch 'MyStandardSwitch' and attaches them to Port Groups 'Management Network' and 'VM Network' respectively.
+If the Port Groups are not present on Standard Switch 'MyStandardSwitch', they are created by the DSC Resource before the migration occurs.
 #>
-Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
+Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNicsWithPortGroups_Config {
     Import-DscResource -ModuleName VMware.vSphereDSC
 
     Node $AllNodes.NodeName {
@@ -68,8 +68,9 @@ Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
             VssName = 'MyStandardSwitch'
             PhysicalNicNames = @('vmnic0', 'vmnic1')
             VMKernelNicNames = @('vmk0', 'vmk1')
+            PortGroupNames = @('Management Network', 'VM Network')
         }
     }
 }
 
-VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config -ConfigurationData $script:configurationData
+VMHostVssMigration_MigratePhysicalNicsAndVMKernelNicsWithPortGroups_Config -ConfigurationData $script:configurationData

--- a/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config.ps1
+++ b/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config.ps1
@@ -1,0 +1,76 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+Param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $User,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Password,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $VMHostName
+)
+
+$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, (ConvertTo-SecureString -String $Password -AsPlainText -Force)
+
+$script:configurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $VMHostName
+        }
+    )
+}
+
+<#
+.DESCRIPTION
+
+Migrates Physical Network Adapters 'vmnic0' and 'vmnic1' to Standard Switch 'MyStandardSwitch'.
+Migrates VMKernel Network Adapters 'vmk0' and 'vmk1' to Standard Switch 'MyStandardSwitch' and attaches them to Port Groups 'Management Network' and 'VM Network' respectively.
+If the Port Groups are not present on Standard Switch 'MyStandardSwitch', they are created by the DSC Resource before the migration occurs.
+#>
+Configuration VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssMigration VMHostVssMigration {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = 'MyStandardSwitch'
+            PhysicalNicNames = @('vmnic0', 'vmnic1')
+            VMKernelNicNames = @('vmk0', 'vmk1')
+            PortGroupNames = @('Management Network', 'VM Network')
+        }
+    }
+}
+
+VMHostVssMigration_MigratePhysicalNicsAndVMKernelNics_Config -ConfigurationData $script:configurationData

--- a/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNics_Config.ps1
+++ b/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration/VMHostVssMigration_MigratePhysicalNics_Config.ps1
@@ -1,0 +1,72 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+Param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $User,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Password,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $VMHostName
+)
+
+$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, (ConvertTo-SecureString -String $Password -AsPlainText -Force)
+
+$script:configurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $VMHostName
+        }
+    )
+}
+
+<#
+.DESCRIPTION
+
+Migrates Physical Network Adapters 'vmnic0' and 'vmnic1' to Standard Switch 'MyStandardSwitch'.
+#>
+Configuration VMHostVssMigration_MigratePhysicalNics_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssMigration VMHostVssMigration {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = 'MyStandardSwitch'
+            PhysicalNicNames = @('vmnic0', 'vmnic1')
+        }
+    }
+}
+
+VMHostVssMigration_MigratePhysicalNics_Config -ConfigurationData $script:configurationData

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
@@ -153,16 +153,18 @@ class VMHostVssMigration : VMHostNetworkMigrationBaseDSC {
 
         for ($i = 0; $i -lt $this.VMKernelNicNames.Length; $i++) {
             $vmKernelNetworkAdapterName = $this.VMKernelNicNames[$i]
-            $portGroupName = $this.PortGroupNames[$i]
 
             $getVMHostNetworkAdapterParams = @{
                 Server = $this.Connection
                 Name = $vmKernelNetworkAdapterName
                 VMHost = $this.VMHost
                 VirtualSwitch = $standardSwitch
-                PortGroup = $portGroupName
                 VMKernel = $true
                 ErrorAction = 'SilentlyContinue'
+            }
+
+            if ($this.PortGroupNames.Length -gt 0) {
+                $getVMHostNetworkAdapterParams.PortGroup = $this.PortGroupNames[$i]
             }
 
             $vmKernelNetworkAdapter = Get-VMHostNetworkAdapter @getVMHostNetworkAdapterParams
@@ -251,9 +253,12 @@ class VMHostVssMigration : VMHostNetworkMigrationBaseDSC {
                 VirtualSwitch = $standardSwitch
                 VMHostPhysicalNic = $physicalNetworkAdapters
                 VMHostVirtualNic = $vmKernelNetworkAdapters
-                VirtualNicPortgroup = $this.PortGroupNames
                 Confirm = $false
                 ErrorAction = 'Stop'
+            }
+
+            if ($this.PortGroupNames.Length -gt 0) {
+                $addVirtualSwitchPhysicalNetworkAdapterParams.VirtualNicPortgroup = $this.PortGroupNames
             }
 
             Add-VirtualSwitchPhysicalNetworkAdapter @addVirtualSwitchPhysicalNetworkAdapterParams

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
@@ -178,11 +178,20 @@ class VMHostVssMigration : VMHostNetworkMigrationBaseDSC {
     .DESCRIPTION
 
     Ensures that the passed VMKernel Network Adapter names and Port Group names count meets the following criteria:
-    The number of passed VMKernel Network Adapter names should be equal to the number of passed Port Group names.
+    If VMKernel Network Adapter names are passed, the following requirements should be met:
+    No Port Group names are passed or the number of Port Group names is the same as the number of VMKernel Network Adapter names.
+    If no VMKernel Network Adapter names are passed, no Port Group names should be passed as well.
     #>
     [void] EnsureVMKernelNetworkAdapterAndPortGroupNamesCountIsCorrect() {
-        if ($this.VMkernelNicNames.Length -ne $this.PortGroupNames.Length) {
-            throw "$($this.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($this.PortGroupNames.Length) Port Groups specified which is not valid."
+        if ($this.VMKernelNicNames.Length -gt 0) {
+            if ($this.PortGroupNames.Length -gt 0 -and $this.VMkernelNicNames.Length -ne $this.PortGroupNames.Length) {
+                throw "$($this.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($this.PortGroupNames.Length) Port Groups specified which is not valid."
+            }
+        }
+        else {
+            if ($this.PortGroupNames.Length -gt 0) {
+                throw "$($this.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($this.PortGroupNames.Length) Port Groups specified which is not valid."
+            }
         }
     }
 

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
@@ -267,7 +267,13 @@ class VMHostVssMigration : VMHostNetworkMigrationBaseDSC {
         $result.VMkernelNicNames = @()
         $result.PortGroupNames = @()
 
-        $vmKernelNetworkAdapters = Get-VMHostNetworkAdapter -Server $this.Connection -VMHost $this.VMHost -VirtualSwitch $standardSwitch -VMKernel -ErrorAction SilentlyContinue
+        if ($this.VMKernelNicNames.Length -eq 0) {
+            return
+        }
+
+        $vmKernelNetworkAdapters = Get-VMHostNetworkAdapter -Server $this.Connection -VMHost $this.VMHost -VirtualSwitch $standardSwitch -VMKernel -ErrorAction SilentlyContinue |
+                                   Where-Object -FilterScript { $this.VMKernelNicNames.Contains($_.Name) }
+
         foreach ($vmKernelNetworkAdapter in $vmKernelNetworkAdapters) {
             $result.VMkernelNicNames += $vmKernelNetworkAdapter.Name
             $result.PortGroupNames += $vmKernelNetworkAdapter.PortGroupName

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.ps1
@@ -1,0 +1,306 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+[DscResource()]
+class VMHostVssMigration : VMHostNetworkMigrationBaseDSC {
+    <#
+    .DESCRIPTION
+
+    Specifies the name of the Standard Switch to which the passed Physical Network Adapters, VMKernel Network Adapters and Port Groups should be part of.
+    #>
+    [DscProperty(Key)]
+    [string] $VssName
+
+    <#
+    .DESCRIPTION
+
+    Specifies the names of the Port Groups to which the specified VMKernel Network Adapters should be attached. Accepts the same number of
+    Port Groups as the number of VMKernel Network Adapters specified. The first Adapter is attached to the first Port Group,
+    the second Adapter to the second Port Group, and so on.
+    #>
+    [DscProperty()]
+    [string[]] $PortGroupNames
+
+    [void] Set() {
+        try {
+            $this.ConnectVIServer()
+            $this.EnsureConnectionIsvCenter()
+
+            $this.RetrieveVMHost()
+            $standardSwitch = $this.GetStandardSwitch()
+
+            $physicalNetworkAdapters = $this.GetPhysicalNetworkAdapters()
+            $filteredPhysicalNetworkAdapters = $this.GetPhysicalNetworkAdaptersNotAddedToStandardSwitch($physicalNetworkAdapters, $standardSwitch)
+
+            if ($filteredPhysicalNetworkAdapters.Length -eq 0) {
+                throw "At least one Physical Network Adapter that is not added to Standard Switch $($standardSwitch.Name) needs to be specified."
+            }
+
+            if ($this.VMkernelNicNames.Length -eq 0) {
+                $this.AddPhysicalNetworkAdaptersToStandardSwitch($filteredPhysicalNetworkAdapters, $standardSwitch)
+            }
+            else {
+                $vmKernelNetworkAdapters = $this.GetVMKernelNetworkAdapters()
+                $this.EnsureVMKernelNetworkAdapterAndPortGroupNamesCountIsCorrect()
+
+                $this.AddPhysicalNetworkAdaptersAndVMKernelNetworkAdaptersToStandardSwitch($filteredPhysicalNetworkAdapters, $vmKernelNetworkAdapters, $standardSwitch)
+            }
+        }
+        finally {
+            $this.DisconnectVIServer()
+        }
+    }
+
+    [bool] Test() {
+        try {
+            $this.ConnectVIServer()
+            $this.EnsureConnectionIsvCenter()
+
+            $this.RetrieveVMHost()
+            $standardSwitch = $this.GetStandardSwitch()
+
+            if ($this.ShouldAddPhysicalNetworkAdaptersToStandardSwitch($standardSwitch)) {
+                return $false
+            }
+
+            if ($this.VMkernelNicNames.Length -eq 0 -and $this.PortGroupNames.Length -eq 0) {
+                return $true
+            }
+            else {
+                return !$this.ShouldAddVMKernelNetworkAdaptersAndPortGroupsToStandardSwitch($standardSwitch)
+            }
+        }
+        finally {
+            $this.DisconnectVIServer()
+        }
+    }
+
+    [VMHostVssMigration] Get() {
+        try {
+            $result = [VMHostVssMigration]::new()
+
+            $this.ConnectVIServer()
+            $this.EnsureConnectionIsvCenter()
+
+            $this.RetrieveVMHost()
+            $standardSwitch = $this.GetStandardSwitch()
+
+            $this.PopulateResult($standardSwitch, $result)
+
+            return $result
+        }
+        finally {
+            $this.DisconnectVIServer()
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Retrieves the Standard Switch with the specified name from the specified VMHost if it exists.
+    Otherwise it throws an exception.
+    #>
+    [PSObject] GetStandardSwitch() {
+        try {
+            $standardSwitch = Get-VirtualSwitch -Server $this.Connection -Name $this.VssName -VMHost $this.VMHost -Standard -ErrorAction Stop
+            return $standardSwitch
+        }
+        catch {
+            throw "Could not retrieve Standard Switch $($this.VssName). For more information: $($_.Exception.Message)"
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Retrieves the Physical Network Adapters that are not added to the specified Standard Switch.
+    #>
+    [array] GetPhysicalNetworkAdaptersNotAddedToStandardSwitch($physicalNetworkAdapters, $standardSwitch) {
+        $filteredPhysicalNetworkAdapters = @()
+
+        if ($null -eq $standardSwitch.Nic) {
+            # No Physical Network Adapters are added to the Standard Switch.
+            return $physicalNetworkAdapters
+        }
+
+        foreach ($physicalNetworkAdapter in $physicalNetworkAdapters) {
+            $addedPhysicalNetworkAdapter = $standardSwitch.Nic | Where-Object -FilterScript { $_ -eq $physicalNetworkAdapter.Name }
+
+            if ($null -eq $addedPhysicalNetworkAdapter) {
+                $filteredPhysicalNetworkAdapters += $physicalNetworkAdapter
+            }
+        }
+
+        return $filteredPhysicalNetworkAdapters
+    }
+
+    <#
+    .DESCRIPTION
+
+    Checks if all passed Physical Network Adapters are added to the Standard Switch.
+    #>
+    [bool] ShouldAddPhysicalNetworkAdaptersToStandardSwitch($standardSwitch) {
+        $physicalNetworkAdapters = $this.GetPhysicalNetworkAdapters()
+        if ($physicalNetworkAdapters.Length -eq 0) {
+            throw 'At least one Physical Network Adapter needs to be specified.'
+        }
+
+        if ($null -eq $standardSwitch.Nic) {
+            # No Physical Network Adapters are added to the Standard Switch.
+            return $true
+        }
+
+        foreach ($physicalNetworkAdapter in $physicalNetworkAdapters) {
+            $addedPhysicalNetworkAdapter = $standardSwitch.Nic | Where-Object -FilterScript { $_ -eq $physicalNetworkAdapter.Name }
+            if ($null -eq $addedPhysicalNetworkAdapter) {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    <#
+    .DESCRIPTION
+
+    Checks if all passed VMKernel Network Adapters and Port Groups are added to the Standard Switch.
+    #>
+    [bool] ShouldAddVMKernelNetworkAdaptersAndPortGroupsToStandardSwitch($standardSwitch) {
+        $this.EnsureVMKernelNetworkAdapterAndPortGroupNamesCountIsCorrect()
+
+        for ($i = 0; $i -lt $this.VMKernelNicNames.Length; $i++) {
+            $vmKernelNetworkAdapterName = $this.VMKernelNicNames[$i]
+            $portGroupName = $this.PortGroupNames[$i]
+
+            $getVMHostNetworkAdapterParams = @{
+                Server = $this.Connection
+                Name = $vmKernelNetworkAdapterName
+                VMHost = $this.VMHost
+                VirtualSwitch = $standardSwitch
+                PortGroup = $portGroupName
+                VMKernel = $true
+                ErrorAction = 'SilentlyContinue'
+            }
+
+            $vmKernelNetworkAdapter = Get-VMHostNetworkAdapter @getVMHostNetworkAdapterParams
+            if ($null -eq $vmKernelNetworkAdapter) {
+                return $true
+            }
+        }
+
+        return $false
+    }
+
+    <#
+    .DESCRIPTION
+
+    Ensures that the passed VMKernel Network Adapter names and Port Group names count meets the following criteria:
+    The number of passed VMKernel Network Adapter names should be equal to the number of passed Port Group names.
+    #>
+    [void] EnsureVMKernelNetworkAdapterAndPortGroupNamesCountIsCorrect() {
+        if ($this.VMkernelNicNames.Length -ne $this.PortGroupNames.Length) {
+            throw "$($this.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($this.PortGroupNames.Length) Port Groups specified which is not valid."
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Ensures that the specified Standard Port Groups exist. If a Standard Port Group is specified and does not exist,
+    it is created on the specified Standard Switch.
+    #>
+    [void] EnsureStandardPortGroupsExist($standardSwitch) {
+        foreach ($standardPortGroupName in $this.PortGroupNames) {
+            $standardPortGroup = Get-VirtualPortGroup -Server $this.Connection -Name $standardPortGroupName -VirtualSwitch $standardSwitch -Standard -ErrorAction SilentlyContinue
+            if ($null -eq $standardPortGroup) {
+                try {
+                    New-VirtualPortGroup -Server $this.Connection -Name $standardPortGroupName -VirtualSwitch $standardSwitch -Confirm:$false -ErrorAction Stop
+                }
+                catch {
+                    throw "Cannot create Standard Port Group $standardPortGroupName on Standard Switch $($standardSwitch.Name). For more information: $($_.Exception.Message)"
+                }
+            }
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Adds the Physical Network Adapters to the specified Standard Switch.
+    #>
+    [void] AddPhysicalNetworkAdaptersToStandardSwitch($physicalNetworkAdapters, $standardSwitch) {
+        try {
+            $addVirtualSwitchPhysicalNetworkAdapterParams = @{
+                Server = $this.Connection
+                VirtualSwitch = $standardSwitch
+                VMHostPhysicalNic = $physicalNetworkAdapters
+                Confirm = $false
+                ErrorAction = 'Stop'
+            }
+
+            Add-VirtualSwitchPhysicalNetworkAdapter @addVirtualSwitchPhysicalNetworkAdapterParams
+        }
+        catch {
+            throw "Could not migrate Physical Network Adapters $($physicalNetworkAdapters) to Standard Switch $($standardSwitch.Name). For more information: $($_.Exception.Message)"
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Adds the Physical Network Adapters and VMKernel Network Adapters to the specified Standard Switch.
+    #>
+    [void] AddPhysicalNetworkAdaptersAndVMKernelNetworkAdaptersToStandardSwitch($physicalNetworkAdapters, $vmKernelNetworkAdapters, $standardSwitch) {
+        $this.EnsureStandardPortGroupsExist($standardSwitch)
+
+        try {
+            $addVirtualSwitchPhysicalNetworkAdapterParams = @{
+                Server = $this.Connection
+                VirtualSwitch = $standardSwitch
+                VMHostPhysicalNic = $physicalNetworkAdapters
+                VMHostVirtualNic = $vmKernelNetworkAdapters
+                VirtualNicPortgroup = $this.PortGroupNames
+                Confirm = $false
+                ErrorAction = 'Stop'
+            }
+
+            Add-VirtualSwitchPhysicalNetworkAdapter @addVirtualSwitchPhysicalNetworkAdapterParams
+        }
+        catch {
+            throw "Could not migrate Physical Network Adapters $($physicalNetworkAdapters) and VMKernel Network Adapters $($vmKernelNetworkAdapters) to Standard Switch $($standardSwitch.Name). For more information: $($_.Exception.Message)"
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Populates the result returned from the Get() method.
+    #>
+    [void] PopulateResult($standardSwitch, $result) {
+        $result.Server = $this.Connection.Name
+        $result.VMHostName = $this.VMHost.Name
+        $result.VssName = $standardSwitch.Name
+        $result.PhysicalNicNames = $standardSwitch.Nic
+        $result.VMkernelNicNames = @()
+        $result.PortGroupNames = @()
+
+        $vmKernelNetworkAdapters = Get-VMHostNetworkAdapter -Server $this.Connection -VMHost $this.VMHost -VirtualSwitch $standardSwitch -VMKernel -ErrorAction SilentlyContinue
+        foreach ($vmKernelNetworkAdapter in $vmKernelNetworkAdapters) {
+            $result.VMkernelNicNames += $vmKernelNetworkAdapter.Name
+            $result.PortGroupNames += $vmKernelNetworkAdapter.PortGroupName
+        }
+    }
+}

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
@@ -83,6 +83,20 @@ Configuration VMHostVDSwitchMigration_CreateManagementVMKernelNetworkAdapterAndv
     }
 }
 
+Configuration VMHostVDSwitchMigration_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssMigration $AllNodes.VMHostVssMigrationResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            PhysicalNicNames = $AllNodes.PhysicalNetworkAdapterNames
+        }
+    }
+}
+
 Configuration VMHostVDSwitchMigration_MigrateOneDisconnectedPhysicalNetworkAdapter_Config {
     Import-DscResource -ModuleName VMware.vSphereDSC
 

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
@@ -235,45 +235,6 @@ Configuration VMHostVDSwitchMigration_MigrateTwoDisconnectedAndOneConnectedPhysi
     }
 }
 
-Configuration VMHostVDSwitchMigration_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup_Config {
-    Import-DscResource -ModuleName VMware.vSphereDSC
-
-    Node $AllNodes.NodeName {
-        VMHostVdsNic $AllNodes.VMHostVdsNicResourceName {
-            Server = $AllNodes.Server
-            Credential = $AllNodes.Credential
-            VMHostName = $AllNodes.VMHostName
-            VdsName = $AllNodes.VDSwitchName
-            PortGroupName = $AllNodes.PortGroupName
-            Ensure = 'Absent'
-        }
-    }
-}
-
-Configuration VMHostVDSwitchMigration_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups_Config {
-    Import-DscResource -ModuleName VMware.vSphereDSC
-
-    Node $AllNodes.NodeName {
-        VMHostVdsNic $AllNodes.VMHostVdsManagementNicResourceName {
-            Server = $AllNodes.Server
-            Credential = $AllNodes.Credential
-            VMHostName = $AllNodes.VMHostName
-            VdsName = $AllNodes.VDSwitchName
-            PortGroupName = $AllNodes.ManagementPortGroupName
-            Ensure = 'Absent'
-        }
-
-        VMHostVdsNic $AllNodes.VMHostVdsvMotionNicResourceName {
-            Server = $AllNodes.Server
-            Credential = $AllNodes.Credential
-            VMHostName = $AllNodes.VMHostName
-            VdsName = $AllNodes.VDSwitchName
-            PortGroupName = $AllNodes.VMotionPortGroupName
-            Ensure = 'Absent'
-        }
-    }
-}
-
 Configuration VMHostVDSwitchMigration_RemoveVDSwitchStandardSwitchAndStandardPortGroup_Config {
     Import-DscResource -ModuleName VMware.vSphereDSC
 

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVssMigration/VMHostVssMigration_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVssMigration/VMHostVssMigration_Config.ps1
@@ -1,0 +1,238 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+Configuration VMHostVssMigration_CreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VDSwitch $AllNodes.VDSwitchResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.VDSwitchName
+            Location = $AllNodes.VDSwitchLocation
+            DatacenterName = $AllNodes.DatacenterName
+            DatacenterLocation = $AllNodes.DatacenterLocation
+            Ensure = 'Present'
+        }
+
+        VDPortGroup $AllNodes.ManagementVDPortGroupResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.ManagementPortGroupName
+            VdsName = $AllNodes.VDSwitchName
+            Ensure = 'Present'
+            DependsOn = $AllNodes.VDSwitchResourceId
+        }
+
+        VDPortGroup $AllNodes.VMotionVDPortGroupResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.VMotionPortGroupName
+            VdsName = $AllNodes.VDSwitchName
+            Ensure = 'Present'
+            DependsOn = $AllNodes.VDSwitchResourceId
+        }
+
+        VMHostVss $AllNodes.VMHostVssResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            Ensure = 'Present'
+        }
+
+        VDSwitchVMHost $AllNodes.VDSwitchVMHostResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VdsName = $AllNodes.VDSwitchName
+            VMHostNames = @($AllNodes.VMHostName)
+            Ensure = 'Present'
+            DependsOn = $AllNodes.VDSwitchResourceId
+        }
+    }
+}
+
+Configuration VMHostVssMigration_CreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVdsNic $AllNodes.VMHostVdsManagementNicResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VdsName = $AllNodes.VDSwitchName
+            PortGroupName = $AllNodes.ManagementPortGroupName
+            Ensure = 'Present'
+            ManagementTrafficEnabled = $AllNodes.ManagementTrafficEnabled
+        }
+
+        VMHostVdsNic $AllNodes.VMHostVdsvMotionNicResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VdsName = $AllNodes.VDSwitchName
+            PortGroupName = $AllNodes.VMotionPortGroupName
+            Ensure = 'Present'
+            VMotionEnabled = $AllNodes.VMotionEnabled
+        }
+    }
+}
+
+Configuration VMHostVssMigration_MigrateThreePhysicalNetworkAdaptersToDistributedSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVDSwitchMigration $AllNodes.VMHostVDSwitchMigrationResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VdsName = $AllNodes.VDSwitchName
+            PhysicalNicNames = $AllNodes.PhysicalNetworkAdapterNames
+        }
+    }
+}
+
+Configuration VMHostVssMigration_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssMigration $AllNodes.VMHostVssMigrationResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            PhysicalNicNames = $AllNodes.PhysicalNetworkAdapterNames
+        }
+    }
+}
+
+Configuration VMHostVssMigration_MigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssMigration $AllNodes.VMHostVssMigrationResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            PhysicalNicNames = $AllNodes.PhysicalNetworkAdapterNames
+            VMKernelNicNames = $AllNodes.VMKernelNetworkAdapterNames
+            PortGroupNames = @($AllNodes.ManagementPortGroupName, $AllNodes.VMotionPortGroupName)
+        }
+    }
+}
+
+Configuration VMHostVssMigration_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VMHostVssNic $AllNodes.VMHostVssManagementNicResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            PortGroupName = $AllNodes.ManagementPortGroupName
+            Ensure = 'Absent'
+        }
+
+        VMHostVssNic $AllNodes.VMHostVssvMotionNicResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            PortGroupName = $AllNodes.VMotionPortGroupName
+            Ensure = 'Absent'
+        }
+    }
+}
+
+Configuration VMHostVssMigration_RemoveVDSwitchAndStandardSwitch_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        VDSwitch $AllNodes.VDSwitchResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.VDSwitchName
+            Location = $AllNodes.VDSwitchLocation
+            DatacenterName = $AllNodes.DatacenterName
+            DatacenterLocation = $AllNodes.DatacenterLocation
+            Ensure = 'Absent'
+        }
+
+        VMHostVssPortGroup $AllNodes.ManagementStandardPortGroupResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            Name = $AllNodes.ManagementPortGroupName
+            VssName = $AllNodes.StandardSwitchName
+            Ensure = 'Absent'
+        }
+
+        VMHostVssPortGroup $AllNodes.VMotionStandardPortGroupResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            VMHostName = $AllNodes.VMHostName
+            Name = $AllNodes.VMotionPortGroupName
+            VssName = $AllNodes.StandardSwitchName
+            Ensure = 'Absent'
+            DependsOn = $AllNodes.ManagementStandardPortGroupResourceId
+        }
+
+        VMHostVss $AllNodes.VMHostVssResourceName {
+            Server = $AllNodes.Server
+            Credential = $AllNodes.Credential
+            Name = $AllNodes.VMHostName
+            VssName = $AllNodes.StandardSwitchName
+            Ensure = 'Absent'
+            DependsOn = $AllNodes.VMotionStandardPortGroupResourceId
+        }
+    }
+}
+
+Configuration VMHostVssMigration_MigratePhysicalNetworkAdaptersToInitialVirtualSwitches_Config {
+    Import-DscResource -ModuleName VMware.vSphereDSC
+
+    Node $AllNodes.NodeName {
+        foreach ($virtualSwitchName in $AllNodes.VirtualSwitches.Keys) {
+            VMHostVssBridge ($AllNodes.VMHostVssBridgeResourceName + $virtualSwitchName) {
+                Server = $AllNodes.Server
+                Credential = $AllNodes.Credential
+                Name = $AllNodes.VMHostName
+                VssName = $virtualSwitchName
+                Ensure = 'Present'
+                NicDevice = $AllNodes.VirtualSwitches.$virtualSwitchName.Nic
+                LinkDiscoveryProtocolOperation = $AllNodes.LinkDiscoveryProtocolOperation
+                LinkDiscoveryProtocolProtocol = $AllNodes.LinkDiscoveryProtocolProtocol
+            }
+
+            VMHostVssTeaming ($AllNodes.VMHostVssTeamingResourceName + $virtualSwitchName) {
+                Server = $AllNodes.Server
+                Credential = $AllNodes.Credential
+                Name = $AllNodes.VMHostName
+                VssName = $virtualSwitchName
+                Ensure = 'Present'
+                ActiveNic = $AllNodes.VirtualSwitches.$virtualSwitchName.ActiveNic
+                StandbyNic = $AllNodes.VirtualSwitches.$virtualSwitchName.StandbyNic
+                CheckBeacon = $AllNodes.VirtualSwitches.$virtualSwitchName.FailureCriteria.CheckBeacon
+                NotifySwitches = $AllNodes.VirtualSwitches.$virtualSwitchName.NotifySwitches
+                Policy = $AllNodes.VirtualSwitches.$virtualSwitchName.Policy
+                RollingOrder = $AllNodes.VirtualSwitches.$virtualSwitchName.RollingOrder
+                DependsOn = "[$($AllNodes.VMHostVssBridgeResourceName)]$($AllNodes.VMHostVssBridgeResourceName)$virtualSwitchName"
+            }
+        }
+    }
+}

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVssMigration/VMHostVssMigration_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVssMigration/VMHostVssMigration_Config.ps1
@@ -65,32 +65,6 @@ Configuration VMHostVssMigration_CreateVDSwitchTwoVDPortGroupsStandardSwitchAndA
     }
 }
 
-Configuration VMHostVssMigration_CreateManagementAndvMotionVMKernelNetworkAdapters_Config {
-    Import-DscResource -ModuleName VMware.vSphereDSC
-
-    Node $AllNodes.NodeName {
-        VMHostVdsNic $AllNodes.VMHostVdsManagementNicResourceName {
-            Server = $AllNodes.Server
-            Credential = $AllNodes.Credential
-            VMHostName = $AllNodes.VMHostName
-            VdsName = $AllNodes.VDSwitchName
-            PortGroupName = $AllNodes.ManagementPortGroupName
-            Ensure = 'Present'
-            ManagementTrafficEnabled = $AllNodes.ManagementTrafficEnabled
-        }
-
-        VMHostVdsNic $AllNodes.VMHostVdsvMotionNicResourceName {
-            Server = $AllNodes.Server
-            Credential = $AllNodes.Credential
-            VMHostName = $AllNodes.VMHostName
-            VdsName = $AllNodes.VDSwitchName
-            PortGroupName = $AllNodes.VMotionPortGroupName
-            Ensure = 'Present'
-            VMotionEnabled = $AllNodes.VMotionEnabled
-        }
-    }
-}
-
 Configuration VMHostVssMigration_MigrateThreePhysicalNetworkAdaptersToDistributedSwitch_Config {
     Import-DscResource -ModuleName VMware.vSphereDSC
 

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostNetworkMigration.Integration.Tests.Helpers.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostNetworkMigration.Integration.Tests.Helpers.ps1
@@ -1,0 +1,213 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+<#
+.DESCRIPTION
+
+Retrieves the name and the location of the Datacenter where the specified VMHost is located.
+Retrieves one connected Physical Network Adapter and two disconnected Physical Network Adapters from the specified VMHost.
+The connected Physical Network Adapter should not be part of a Standard Switch which has VMKernel Network Adapter that has
+Management Traffic enabled.
+If the criteria is not met, it throws an exception.
+#>
+function Invoke-TestSetup {
+    # Data that is going to be passed as Configuration Data in the Integration Tests.
+    $script:datacenterName = $null
+    $script:datacenterLocation = $null
+    $script:physicalNetworkAdapters = @()
+    $script:virtualSwitchesWithPhysicalNics = @{}
+
+    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
+    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
+    $networkSystem = Get-View -Server $viServer -Id $vmHost.ExtensionData.ConfigManager.NetworkSystem -ErrorAction Stop
+    $datacenter = Get-Datacenter -Server $viServer -VMHost $vmHost -ErrorAction Stop
+
+    $script:datacenterName = $datacenter.Name
+
+    # If the Parent of the Parent Folder is $null, the Datacenter is located in the Root Folder of the Inventory.
+    if ($null -eq $datacenter.ParentFolder.Parent) {
+        $script:datacenterLocation = [string]::Empty
+    }
+    else {
+        $locationItems = @()
+        $child = $datacenter.ParentFolder
+        $parent = $datacenter.ParentFolder.Parent
+
+        while ($true) {
+            if ($null -eq $parent) {
+                break
+            }
+
+            $locationItems += $child.Name
+            $child = $parent
+            $parent = $parent.Parent
+        }
+
+        # The Parent Folder of the Datacenter should be the last item in the array.
+        [array]::Reverse($locationItems)
+
+        # Folder names for Datacenter Location should be separated by '/'.
+        $script:datacenterLocation = [string]::Join('/', $locationItems)
+    }
+
+    $disconnectedPhysicalNetworkAdapters = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -Physical -ErrorAction Stop |
+                                           Where-Object -FilterScript { $_.BitRatePerSec -eq 0 } |
+                                           Select-Object -First 2
+    if ($disconnectedPhysicalNetworkAdapters.Length -lt 2) {
+        throw 'The Integration Tests require at least two disconnected Physical Network Adapters to be available on the ESXi node.'
+    }
+
+    $script:physicalNetworkAdapters += $disconnectedPhysicalNetworkAdapters[0].Name
+    $script:physicalNetworkAdapters += $disconnectedPhysicalNetworkAdapters[1].Name
+
+    <#
+    Store the initial Standard Switches for every Physical Network Adapter in the Virtual Switches hashtable, so
+    a migration can be performed after the Tests have executed. The Physical Network Adapter will be added again to
+    their initial Standard Switches.
+    #>
+    foreach ($physicalNetworkAdapter in $disconnectedPhysicalNetworkAdapters) {
+        $virtualSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -ErrorAction Stop | Where-Object { $null -ne $_.Nic -and $_.Nic.Contains($physicalNetworkAdapter.Name) }
+        if ($null -eq $virtualSwitch) {
+            continue
+        }
+
+        $virtualSwitchName = $virtualSwitch.Name
+        $virtualSwitchNicTeamingPolicy = $networkSystem.NetworkConfig.Vswitch |
+                                         Where-Object { $_.Name -eq $virtualSwitch.Name } |
+                                         Select-Object -ExpandProperty Spec |
+                                         Select-Object -ExpandProperty Policy |
+                                         Select-Object -ExpandProperty NicTeaming
+
+        $script:virtualSwitchesWithPhysicalNics.$virtualSwitchName = @{
+            Nic = $virtualSwitch.Nic
+            ActiveNic = $virtualSwitchNicTeamingPolicy.NicOrder.ActiveNic
+            StandbyNic = $virtualSwitchNicTeamingPolicy.NicOrder.StandbyNic
+            CheckBeacon = $virtualSwitchNicTeamingPolicy.FailureCriteria.CheckBeacon
+            NotifySwitches = $virtualSwitchNicTeamingPolicy.NotifySwitches
+            Policy = $virtualSwitchNicTeamingPolicy.Policy
+            RollingOrder = $virtualSwitchNicTeamingPolicy.RollingOrder
+        }
+    }
+
+    $connectedPhysicalNetworkAdapters = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -Physical -ErrorAction Stop |
+                                        Where-Object -FilterScript { $_.BitRatePerSec -ne 0 }
+    if ($connectedPhysicalNetworkAdapters.Length -lt 1) {
+        throw 'The Integration Tests require at least one connected Physical Network Adapter to be available on the ESXi node.'
+    }
+
+    <#
+    Here we retrieve the names of the Port Groups to which VMKernel Network Adapters with Management Traffic enabled are connected.
+    #>
+    $portGroupNamesOfVMKernelsWithManagementTrafficEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VMKernel -ErrorAction Stop |
+                                                             Where-Object { $_.ManagementTrafficEnabled } |
+                                                             Select-Object -ExpandProperty PortGroupName
+
+    <#
+    For connected Physical Network Adapters, we need to retrieve only one of them that meets the following criteria:
+    The Physical Network Adapter should not be part of a Standard Switch or the Physical Network Adapter is part of a Standard Switch
+    that does not have a VMKernel Network Adapter that has Management Traffic enabled.
+    #>
+    foreach ($physicalNetworkAdapter in $connectedPhysicalNetworkAdapters) {
+        $virtualSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -ErrorAction Stop | Where-Object { $null -ne $_.Nic -and $_.Nic.Contains($physicalNetworkAdapter.Name) }
+        if ($null -eq $virtualSwitch) {
+            $script:physicalNetworkAdapters += $physicalNetworkAdapter.Name
+            break
+        }
+
+        $virtualPortGroups = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -VirtualSwitch $virtualSwitch -ErrorAction Stop |
+                             Where-Object { $_.VirtualSwitchName -eq $virtualSwitch.Name -and $portGroupNamesOfVMKernelsWithManagementTrafficEnabled.Contains($_.Name) }
+        if ($virtualPortGroups.Length -gt 0) {
+            continue
+        }
+        else {
+            $script:physicalNetworkAdapters += $physicalNetworkAdapter.Name
+            $virtualSwitchName = $virtualSwitch.Name
+            $virtualSwitchNicTeamingPolicy = $networkSystem.NetworkConfig.Vswitch |
+                                         Where-Object { $_.Name -eq $virtualSwitch.Name } |
+                                         Select-Object -ExpandProperty Spec |
+                                         Select-Object -ExpandProperty Policy |
+                                         Select-Object -ExpandProperty NicTeaming
+
+            $script:virtualSwitchesWithPhysicalNics.$virtualSwitchName = @{
+                Nic = $virtualSwitch.Nic
+                ActiveNic = $virtualSwitchNicTeamingPolicy.NicOrder.ActiveNic
+                StandbyNic = $virtualSwitchNicTeamingPolicy.NicOrder.StandbyNic
+                CheckBeacon = $virtualSwitchNicTeamingPolicy.FailureCriteria.CheckBeacon
+                NotifySwitches = $virtualSwitchNicTeamingPolicy.NotifySwitches
+                Policy = $virtualSwitchNicTeamingPolicy.Policy
+                RollingOrder = $virtualSwitchNicTeamingPolicy.RollingOrder
+            }
+
+            break
+        }
+    }
+
+    Disconnect-VIServer -Server $Server -Confirm:$false
+}
+
+<#
+.DESCRIPTION
+
+Retrieves the names of the VMKernel Network Adapters connected to Standard Switch used in the Integration Tests.
+#>
+function Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch {
+    [CmdletBinding()]
+
+    $standardSwitchName = $script:configurationData.AllNodes.StandardSwitchName
+    $managementPortGroupName = $script:configurationData.AllNodes.ManagementPortGroupName
+    $vMotionPortGroupName = $script:configurationData.AllNodes.VMotionPortGroupName
+
+    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
+    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
+    $standardSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -Name $standardSwitchName -ErrorAction Stop
+    $managementPortGroup = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -Name $managementPortGroupName -ErrorAction Stop
+    $vMotionPortGroup = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -Name $vMotionPortGroupName -ErrorAction Stop
+
+    $vmKernelNetworkAdapterWithManagementTrafficEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $standardSwitch -PortGroup $managementPortGroup -VMKernel -ErrorAction Stop
+    $vmKernelNetworkAdapterWithvMotionEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $standardSwitch -PortGroup $vMotionPortGroup -VMKernel -ErrorAction Stop
+
+    # Here we need to modify the Configuration Data passed to each Configuration to include the retrieved VMKernel Network Adapter names.
+    $script:configurationData.AllNodes[0].VMKernelNetworkAdapterNames = @($vmKernelNetworkAdapterWithManagementTrafficEnabled.Name, $vmKernelNetworkAdapterWithvMotionEnabled.Name)
+
+    Disconnect-VIServer -Server $Server -Confirm:$false
+}
+
+<#
+.DESCRIPTION
+
+Retrieves the names of the VMKernel Network Adapters connected to Distributed Switch used in the Integration Tests.
+#>
+function Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch {
+    [CmdletBinding()]
+
+    $distributedSwitchName = $script:configurationData.AllNodes.VDSwitchName
+    $managementPortGroupName = $script:configurationData.AllNodes.ManagementPortGroupName
+    $vMotionPortGroupName = $script:configurationData.AllNodes.VMotionPortGroupName
+
+    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
+    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
+    $distributedSwitch = Get-VDSwitch -Server $viServer -Name $distributedSwitchName -ErrorAction Stop
+    $managementPortGroup = Get-VDPortgroup -Server $viServer -Name $managementPortGroupName -VDSwitch $distributedSwitch -ErrorAction Stop
+    $vMotionPortGroup = Get-VDPortgroup -Server $viServer -Name $vMotionPortGroupName -VDSwitch $distributedSwitch -ErrorAction Stop
+
+    $vmKernelNetworkAdapterWithManagementTrafficEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $distributedSwitch -PortGroup $managementPortGroup -VMKernel -ErrorAction Stop
+    $vmKernelNetworkAdapterWithvMotionEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $distributedSwitch -PortGroup $vMotionPortGroup -VMKernel -ErrorAction Stop
+
+    # Here we need to modify the Configuration Data passed to each Configuration to include the retrieved VMKernel Network Adapter names.
+    $script:configurationData.AllNodes[0].VMKernelNetworkAdapterNames = @($vmKernelNetworkAdapterWithManagementTrafficEnabled.Name, $vmKernelNetworkAdapterWithvMotionEnabled.Name)
+
+    Disconnect-VIServer -Server $Server -Confirm:$false
+}

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
@@ -67,9 +67,6 @@ $script:configurationData = @{
             VMHostVssTeamingResourceName = 'VMHostVssTeaming'
             VMHostVssManagementNicResourceName = 'VMHostVssManagementNic'
             VMHostVssvMotionNicResourceName = 'VMHostVssvMotionNic'
-            VMHostVdsNicResourceName = 'VMHostVdsNic'
-            VMHostVdsManagementNicResourceName = 'VMHostVdsManagementNic'
-            VMHostVdsvMotionNicResourceName = 'VMHostVdsvMotionNic'
             StandardSwitchName = 'MyTestStandardSwitch'
             VDSwitchName = 'MyTestVDSwitch'
             VDSwitchLocation = [string]::Empty
@@ -100,8 +97,6 @@ $script:configMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAda
 $script:configMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups = "$($script:dscResourceName)_MigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups_Config"
 $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroup = "$($script:dscResourceName)_MigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroup_Config"
 $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups = "$($script:dscResourceName)_MigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups_Config"
-$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup = "$($script:dscResourceName)_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup_Config"
-$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups = "$($script:dscResourceName)_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups_Config"
 $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup = "$($script:dscResourceName)_RemoveVDSwitchStandardSwitchAndStandardPortGroup_Config"
 $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = "$($script:dscResourceName)_MigratePhysicalNetworkAdaptersToInitialVirtualSwitches_Config"
 
@@ -119,8 +114,6 @@ $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAd
 $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath = "$script:integrationTestsFolderPath\$script:configMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups\"
 $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroupPath = "$script:integrationTestsFolderPath\$script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroup\"
 $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath = "$script:integrationTestsFolderPath\$script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups\"
-$script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup\"
-$script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups\"
 $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath = "$script:integrationTestsFolderPath\$script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup\"
 $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath = "$script:integrationTestsFolderPath\$script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches\"
 
@@ -665,11 +658,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -679,15 +667,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -708,14 +687,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToTheSamePortGroup
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndOnePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }
@@ -838,11 +817,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -852,15 +826,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -881,14 +846,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToDifferentPortGroups
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }
@@ -1017,11 +982,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -1031,15 +991,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -1060,14 +1011,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToTheSamePortGroup
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }
@@ -1196,11 +1147,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -1210,15 +1156,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -1239,14 +1176,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToDifferentPortGroups
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }
@@ -1372,11 +1309,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -1386,15 +1318,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -1415,14 +1338,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroup
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToTheSamePortGroup
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToTheSamePortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }
@@ -1548,11 +1471,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configRemoveVDSwitchStandardSwitchAndStandardPortGroup `
                 -OutputPath $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath `
                 -ConfigurationData $script:configurationData `
@@ -1562,15 +1480,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
-
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
 
             $startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup = @{
                 Path = $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath
@@ -1591,14 +1500,14 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroups
+            Remove-ManagementAndvMotionVMKernelNetworkAdaptersConnectedToDifferentPortGroups
+
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchStandardSwitchAndStandardPortGroup
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterConnectedToDifferentPortGroupsPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchStandardSwitchAndStandardPortGroupPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
@@ -36,191 +36,7 @@ Param(
     $Name
 )
 
-<#
-Retrieves the name and the location of the Datacenter where the specified VMHost is located.
-Retrieves one connected Physical Network Adapter and two disconnected Physical Network Adapters from the specified VMHost.
-The connected Physical Network Adapter should not be part of a Standard Switch which has VMKernel Network Adapter that has
-Management Traffic enabled.
-If the criteria is not met, it throws an exception.
-#>
-function Invoke-TestSetup {
-    # Data that is going to be passed as Configuration Data in the Integration Tests.
-    $script:datacenterName = $null
-    $script:datacenterLocation = $null
-    $script:physicalNetworkAdapters = @()
-    $script:virtualSwitchesWithPhysicalNics = @{}
-
-    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
-    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
-    $networkSystem = Get-View -Server $viServer -Id $vmHost.ExtensionData.ConfigManager.NetworkSystem -ErrorAction Stop
-    $datacenter = Get-Datacenter -Server $viServer -VMHost $vmHost -ErrorAction Stop
-
-    $script:datacenterName = $datacenter.Name
-
-    # If the Parent of the Parent Folder is $null, the Datacenter is located in the Root Folder of the Inventory.
-    if ($null -eq $datacenter.ParentFolder.Parent) {
-        $script:datacenterLocation = [string]::Empty
-    }
-    else {
-        $locationItems = @()
-        $child = $datacenter.ParentFolder
-        $parent = $datacenter.ParentFolder.Parent
-
-        while ($true) {
-            if ($null -eq $parent) {
-                break
-            }
-
-            $locationItems += $child.Name
-            $child = $parent
-            $parent = $parent.Parent
-        }
-
-        # The Parent Folder of the Datacenter should be the last item in the array.
-        [array]::Reverse($locationItems)
-
-        # Folder names for Datacenter Location should be separated by '/'.
-        $script:datacenterLocation = [string]::Join('/', $locationItems)
-    }
-
-    $disconnectedPhysicalNetworkAdapters = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -Physical -ErrorAction Stop |
-                                           Where-Object -FilterScript { $_.BitRatePerSec -eq 0 } |
-                                           Select-Object -First 2
-    if ($disconnectedPhysicalNetworkAdapters.Length -lt 2) {
-        throw 'The Integration Tests require at least two disconnected Physical Network Adapters to be available on the ESXi node.'
-    }
-
-    $script:physicalNetworkAdapters += $disconnectedPhysicalNetworkAdapters[0].Name
-    $script:physicalNetworkAdapters += $disconnectedPhysicalNetworkAdapters[1].Name
-
-    <#
-    Store the initial Standard Switches for every Physical Network Adapter in the Virtual Switches hashtable, so
-    a migration can be performed after the Tests have executed. The Physical Network Adapter will be added again to
-    their initial Standard Switches.
-    #>
-    foreach ($physicalNetworkAdapter in $disconnectedPhysicalNetworkAdapters) {
-        $virtualSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -ErrorAction Stop | Where-Object { $null -ne $_.Nic -and $_.Nic.Contains($physicalNetworkAdapter.Name) }
-        if ($null -eq $virtualSwitch) {
-            continue
-        }
-
-        $virtualSwitchName = $virtualSwitch.Name
-        $virtualSwitchNicTeamingPolicy = $networkSystem.NetworkConfig.Vswitch |
-                                         Where-Object { $_.Name -eq $virtualSwitch.Name } |
-                                         Select-Object -ExpandProperty Spec |
-                                         Select-Object -ExpandProperty Policy |
-                                         Select-Object -ExpandProperty NicTeaming
-
-        $script:virtualSwitchesWithPhysicalNics.$virtualSwitchName = @{
-            Nic = $virtualSwitch.Nic
-            ActiveNic = $virtualSwitchNicTeamingPolicy.NicOrder.ActiveNic
-            StandbyNic = $virtualSwitchNicTeamingPolicy.NicOrder.StandbyNic
-            CheckBeacon = $virtualSwitchNicTeamingPolicy.FailureCriteria.CheckBeacon
-            NotifySwitches = $virtualSwitchNicTeamingPolicy.NotifySwitches
-            Policy = $virtualSwitchNicTeamingPolicy.Policy
-            RollingOrder = $virtualSwitchNicTeamingPolicy.RollingOrder
-        }
-    }
-
-    $connectedPhysicalNetworkAdapters = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -Physical -ErrorAction Stop |
-                                        Where-Object -FilterScript { $_.BitRatePerSec -ne 0 }
-    if ($connectedPhysicalNetworkAdapters.Length -lt 1) {
-        throw 'The Integration Tests require at least one connected Physical Network Adapter to be available on the ESXi node.'
-    }
-
-    <#
-    Here we retrieve the names of the Port Groups to which VMKernel Network Adapters with Management Traffic enabled are connected.
-    #>
-    $portGroupNamesOfVMKernelsWithManagementTrafficEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VMKernel -ErrorAction Stop |
-                                                             Where-Object { $_.ManagementTrafficEnabled } |
-                                                             Select-Object -ExpandProperty PortGroupName
-
-    <#
-    For connected Physical Network Adapters, we need to retrieve only one of them that meets the following criteria:
-    The Physical Network Adapter should not be part of a Standard Switch or the Physical Network Adapter is part of a Standard Switch
-    that does not have a VMKernel Network Adapter that has Management Traffic enabled.
-    #>
-    foreach ($physicalNetworkAdapter in $connectedPhysicalNetworkAdapters) {
-        $virtualSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -ErrorAction Stop | Where-Object { $null -ne $_.Nic -and $_.Nic.Contains($physicalNetworkAdapter.Name) }
-        if ($null -eq $virtualSwitch) {
-            $script:physicalNetworkAdapters += $physicalNetworkAdapter.Name
-            break
-        }
-
-        $virtualPortGroups = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -VirtualSwitch $virtualSwitch -ErrorAction Stop |
-                             Where-Object { $_.VirtualSwitchName -eq $virtualSwitch.Name -and $portGroupNamesOfVMKernelsWithManagementTrafficEnabled.Contains($_.Name) }
-        if ($virtualPortGroups.Length -gt 0) {
-            continue
-        }
-        else {
-            $script:physicalNetworkAdapters += $physicalNetworkAdapter.Name
-            $virtualSwitchName = $virtualSwitch.Name
-            $virtualSwitchNicTeamingPolicy = $networkSystem.NetworkConfig.Vswitch |
-                                         Where-Object { $_.Name -eq $virtualSwitch.Name } |
-                                         Select-Object -ExpandProperty Spec |
-                                         Select-Object -ExpandProperty Policy |
-                                         Select-Object -ExpandProperty NicTeaming
-
-            $script:virtualSwitchesWithPhysicalNics.$virtualSwitchName = @{
-                Nic = $virtualSwitch.Nic
-                ActiveNic = $virtualSwitchNicTeamingPolicy.NicOrder.ActiveNic
-                StandbyNic = $virtualSwitchNicTeamingPolicy.NicOrder.StandbyNic
-                CheckBeacon = $virtualSwitchNicTeamingPolicy.FailureCriteria.CheckBeacon
-                NotifySwitches = $virtualSwitchNicTeamingPolicy.NotifySwitches
-                Policy = $virtualSwitchNicTeamingPolicy.Policy
-                RollingOrder = $virtualSwitchNicTeamingPolicy.RollingOrder
-            }
-
-            break
-        }
-    }
-
-    Disconnect-VIServer -Server $Server -Confirm:$false
-}
-
-function Add-PhysicalNetworkAdaptersToStandardSwitch {
-    [CmdletBinding()]
-
-    $standardSwitchName = $script:configurationData.AllNodes.StandardSwitchName
-    $physicalNetworkAdapterNames = $script:configurationData.AllNodes.PhysicalNetworkAdapterNames
-
-    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
-    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
-    $standardSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -Name $standardSwitchName -ErrorAction Stop
-
-    $physicalNetworkAdapters = @()
-    foreach ($physicalNetworkAdapterName in $physicalNetworkAdapterNames) {
-        $physicalNetworkAdapter = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -Name $physicalNetworkAdapterName -Physical -ErrorAction Stop
-        $physicalNetworkAdapters += $physicalNetworkAdapter
-    }
-
-    Add-VirtualSwitchPhysicalNetworkAdapter -Server $viServer -VirtualSwitch $standardSwitch -VMHostPhysicalNic $physicalNetworkAdapters -Confirm:$false -ErrorAction Stop
-
-    Disconnect-VIServer -Server $Server -Confirm:$false
-}
-
-function Get-VMKernelNetworkAdapterNames {
-    [CmdletBinding()]
-
-    $standardSwitchName = $script:configurationData.AllNodes.StandardSwitchName
-    $managementPortGroupName = $script:configurationData.AllNodes.ManagementPortGroupName
-    $vMotionPortGroupName = $script:configurationData.AllNodes.VMotionPortGroupName
-
-    $viServer = Connect-VIServer -Server $Server -User $User -Password $Password -ErrorAction Stop
-    $vmHost = Get-VMHost -Server $viServer -Name $Name -ErrorAction Stop
-    $standardSwitch = Get-VirtualSwitch -Server $viServer -VMHost $vmHost -Name $standardSwitchName -ErrorAction Stop
-    $managementPortGroup = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -Name $managementPortGroupName -ErrorAction Stop
-    $vMotionPortGroup = Get-VirtualPortGroup -Server $viServer -VMHost $vmHost -Name $vMotionPortGroupName -ErrorAction Stop
-
-    $vmKernelNetworkAdapterWithManagementTrafficEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $standardSwitch -PortGroup $managementPortGroup -VMKernel -ErrorAction Stop
-    $vmKernelNetworkAdapterWithvMotionEnabled = Get-VMHostNetworkAdapter -Server $viServer -VMHost $vmHost -VirtualSwitch $standardSwitch -PortGroup $vMotionPortGroup -VMKernel -ErrorAction Stop
-
-    # Here we need to modify the Configuration Data passed to each Configuration to include the retrieved VMKernel Network Adapter names.
-    $script:configurationData.AllNodes[0].VMKernelNetworkAdapterNames = @($vmKernelNetworkAdapterWithManagementTrafficEnabled.Name, $vmKernelNetworkAdapterWithvMotionEnabled.Name)
-
-    Disconnect-VIServer -Server $Server -Confirm:$false
-}
-
+. "$PSScriptRoot\VMHostNetworkMigration.Integration.Tests.Helpers.ps1"
 Invoke-TestSetup
 
 $Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, (ConvertTo-SecureString -String $Password -AsPlainText -Force)
@@ -245,6 +61,7 @@ $script:configurationData = @{
             VDSwitchResourceName = 'VDSwitch'
             VDSwitchResourceId = '[VDSwitch]VDSwitch'
             VDSwitchVMHostResourceName = 'VDSwitchVMHost'
+            VMHostVssMigrationResourceName = 'VMHostVssMigration'
             VMHostVDSwitchMigrationResourceName = 'VMHostVDSwitchMigration'
             VMHostVssBridgeResourceName = 'VMHostVssBridge'
             VMHostVssTeamingResourceName = 'VMHostVssTeaming'
@@ -273,6 +90,7 @@ $script:configurationData = @{
 
 $script:configCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = "$($script:dscResourceName)_CreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch_Config"
 $script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter = "$($script:dscResourceName)_CreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter_Config"
+$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config"
 $script:configMigrateOneDisconnectedPhysicalNetworkAdapter = "$($script:dscResourceName)_MigrateOneDisconnectedPhysicalNetworkAdapter_Config"
 $script:configMigrateTwoDisconnectedPhysicalNetworkAdapters = "$($script:dscResourceName)_MigrateTwoDisconnectedPhysicalNetworkAdapters_Config"
 $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdapters = "$($script:dscResourceName)_MigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdapters_Config"
@@ -291,6 +109,7 @@ $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = "$($scrip
 
 $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath = "$script:integrationTestsFolderPath\$script:configCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch\"
 $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath = "$script:integrationTestsFolderPath\$script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter\"
+$script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch\"
 $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterPath = "$script:integrationTestsFolderPath\$script:configMigrateOneDisconnectedPhysicalNetworkAdapter\"
 $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersPath = "$script:integrationTestsFolderPath\$script:configMigrateTwoDisconnectedPhysicalNetworkAdapters\"
 $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersPath = "$script:integrationTestsFolderPath\$script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdapters\"
@@ -314,6 +133,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             & $script:configMigrateOneDisconnectedPhysicalNetworkAdapter `
                 -OutputPath $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterPath `
                 -ConfigurationData $script:configurationData `
@@ -321,6 +145,15 @@ Describe "$($script:dscResourceName)_Integration" {
 
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -339,10 +172,7 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
-
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
             Start-DscConfiguration @startDscConfigurationParametersMigrateOneDisconnectedPhysicalNetworkAdapter
         }
 
@@ -441,6 +271,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             & $script:configMigrateTwoDisconnectedPhysicalNetworkAdapters `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersPath `
                 -ConfigurationData $script:configurationData `
@@ -448,6 +283,15 @@ Describe "$($script:dscResourceName)_Integration" {
 
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -466,10 +310,7 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
-
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
             Start-DscConfiguration @startDscConfigurationParametersMigrateTwoDisconnectedPhysicalNetworkAdapters
         }
 
@@ -574,6 +415,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             & $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdapters `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersPath `
                 -ConfigurationData $script:configurationData `
@@ -581,6 +427,15 @@ Describe "$($script:dscResourceName)_Integration" {
 
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -599,10 +454,7 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
-
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
             Start-DscConfiguration @startDscConfigurationParametersMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdapters
         }
 
@@ -709,6 +561,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -727,14 +584,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndOnePortGroup `
                 -OutputPath $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndOnePortGroupPath `
@@ -870,6 +734,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -888,14 +757,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndTwoPortGroups `
                 -OutputPath $script:mofFileMigrateOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath `
@@ -1031,6 +907,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -1049,14 +930,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroup `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroupPath `
@@ -1198,6 +1086,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -1216,14 +1109,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath `
@@ -1365,6 +1265,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -1383,14 +1288,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroup `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndOnePortGroupPath `
@@ -1529,6 +1441,11 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
             $startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
@@ -1547,14 +1464,21 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateStandardSwitchStandardPortGroupVDSwitchAndAddVMHostToVDSwitch
             Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
 
-            # TODO: Replace with DSC Resource that migrates Physical Network Adapters to the specified Standard Switch.
-            Add-PhysicalNetworkAdaptersToStandardSwitch
-
-            Get-VMKernelNetworkAdapterNames
+            Get-VMKernelNetworkAdapterNamesConnectedToStandardSwitch
 
             & $script:configMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroups `
                 -OutputPath $script:mofFileMigrateTwoDisconnectedAndOneConnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAdaptersAndTwoPortGroupsPath `

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
@@ -1,0 +1,425 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+Param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $User,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Password,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Name
+)
+
+. "$PSScriptRoot\VMHostNetworkMigration.Integration.Tests.Helpers.ps1"
+Invoke-TestSetup
+
+$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, (ConvertTo-SecureString -String $Password -AsPlainText -Force)
+
+$script:dscResourceName = 'VMHostVssMigration'
+$script:moduleFolderPath = (Get-Module -Name 'VMware.vSphereDSC' -ListAvailable).ModuleBase
+$script:integrationTestsFolderPath = Join-Path -Path (Join-Path -Path $moduleFolderPath -ChildPath 'Tests') -ChildPath 'Integration'
+$script:configurationFile = "$script:integrationTestsFolderPath\Configurations\$script:dscResourceName\$($script:dscResourceName)_Config.ps1"
+
+$script:configurationData = @{
+    AllNodes = @(
+        @{
+            NodeName = 'localhost'
+            PSDscAllowPlainTextPassword = $true
+            Server = $Server
+            Credential = $Credential
+            VMHostName = $Name
+            VDSwitchResourceName = 'VDSwitch'
+            VDSwitchResourceId = '[VDSwitch]VDSwitch'
+            ManagementVDPortGroupResourceName = 'ManagementVDPortGroup'
+            ManagementStandardPortGroupResourceName = 'ManagementStandardPortGroup'
+            ManagementStandardPortGroupResourceId = '[VMHostVssPortGroup]ManagementStandardPortGroup'
+            VMotionVDPortGroupResourceName = 'VMotionVDPortGroup'
+            VMotionStandardPortGroupResourceName = 'VMotionStandardPortGroup'
+            VMotionStandardPortGroupResourceId = '[VMHostVssPortGroup]VMotionStandardPortGroup'
+            VMHostVssResourceName = 'VMHostVss'
+            VDSwitchVMHostResourceName = 'VDSwitchVMHost'
+            VMHostVdsManagementNicResourceName = 'VMHostVdsManagementNic'
+            VMHostVdsvMotionNicResourceName = 'VMHostVdsvMotionNic'
+            VMHostVDSwitchMigrationResourceName = 'VMHostVDSwitchMigration'
+            VMHostVssMigrationResourceName = 'VMHostVssMigration'
+            VMHostVssManagementNicResourceName = 'VMHostVssManagementNic'
+            VMHostVssvMotionNicResourceName = 'VMHostVssvMotionNic'
+            VMHostVssBridgeResourceName = 'VMHostVssBridge'
+            VMHostVssTeamingResourceName = 'VMHostVssTeaming'
+            VDSwitchName = 'MyTestVDSwitch'
+            VDSwitchLocation = [string]::Empty
+            DatacenterName = $script:datacenterName
+            DatacenterLocation = $script:datacenterLocation
+            ManagementPortGroupName = 'MyManagementPortGroup'
+            VMotionPortGroupName = 'MyvMotionPortGroup'
+            StandardSwitchName = 'MyTestStandardSwitch'
+            ManagementTrafficEnabled = $true
+            VMotionEnabled = $true
+            PhysicalNetworkAdapterNames = $script:physicalNetworkAdapters
+            VirtualSwitches = $script:virtualSwitchesWithPhysicalNics
+            LinkDiscoveryProtocolOperation = 'Listen'
+            LinkDiscoveryProtocolProtocol = 'CDP'
+        }
+    )
+}
+
+$script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = "$($script:dscResourceName)_CreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch_Config"
+$script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter = "$($script:dscResourceName)_CreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter_Config"
+$script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToDistributedSwitch_Config"
+$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config"
+$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch_Config"
+$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch = "$($script:dscResourceName)_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch_Config"
+$script:configRemoveVDSwitchAndStandardSwitch = "$($script:dscResourceName)_RemoveVDSwitchAndStandardSwitch_Config"
+$script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = "$($script:dscResourceName)_MigratePhysicalNetworkAdaptersToInitialVirtualSwitches_Config"
+
+. $script:configurationFile -ErrorAction Stop
+
+$script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath = "$script:integrationTestsFolderPath\$script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch\"
+$script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath = "$script:integrationTestsFolderPath\$script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter\"
+$script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch\"
+$script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch\"
+$script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch\"
+$script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch\"
+$script:mofFileRemoveVDSwitchAndStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveVDSwitchAndStandardSwitch\"
+$script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath = "$script:integrationTestsFolderPath\$script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches\"
+
+Describe "$($script:dscResourceName)_Integration" {
+    Context "When using configuration $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch" {
+        BeforeAll {
+            # Arrange
+            & $script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch `
+                -OutputPath $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = @{
+                Path = $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToStandardSwitch
+        }
+
+        It 'Should apply the MOF without throwing' {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            { Start-DscConfiguration @startDscConfigurationParameters } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            # Arrange && Act && Assert
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration and all parameters should match' {
+            # Arrange && Act
+            $configuration = Get-DscConfiguration -Verbose -ErrorAction Stop | Where-Object -FilterScript { $_.ConfigurationName -eq $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch }
+
+            # Assert
+            $configuration.Server | Should -Be $script:configurationData.AllNodes.Server
+            $configuration.VMHostName | Should -Be $script:configurationData.AllNodes.VMHostName
+            $configuration.VssName | Should -Be $script:configurationData.AllNodes.StandardSwitchName
+            $configuration.PhysicalNicNames | Should -Be $script:configurationData.AllNodes.PhysicalNetworkAdapterNames
+            $configuration.VMKernelNicNames | Should -Be @()
+            $configuration.PortGroupNames | Should -Be @()
+        }
+
+        It 'Should return $true when Test-DscConfiguration is run' {
+            # Arrange
+            $testDscConfigurationParameters = @{
+                ReferenceConfiguration = "$script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath\$($script:configurationData.AllNodes.NodeName).mof"
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            (Test-DscConfiguration @testDscConfigurationParameters).InDesiredState | Should -Be $true
+        }
+
+        AfterAll {
+            # Arrange
+            & $script:configRemoveVDSwitchAndStandardSwitch `
+                -OutputPath $script:mofFileRemoveVDSwitchAndStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches `
+                -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch = @{
+                Path = $script:mofFileRemoveVDSwitchAndStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = @{
+                Path = $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
+
+            Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveVDSwitchAndStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
+        }
+    }
+
+    Context "When using configuration $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch" {
+        BeforeAll {
+            # Arrange
+            & $script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch `
+                -OutputPath $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter `
+                -OutputPath $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = @{
+                Path = $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter = @{
+                Path = $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
+            Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
+
+            Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch
+        }
+
+        It 'Should apply the MOF without throwing' {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            { Start-DscConfiguration @startDscConfigurationParameters } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            # Arrange && Act && Assert
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration and all parameters should match' {
+            # Arrange && Act
+            $configuration = Get-DscConfiguration -Verbose -ErrorAction Stop | Where-Object -FilterScript { $_.ConfigurationName -eq $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch }
+
+            # Assert
+            $configuration.Server | Should -Be $script:configurationData.AllNodes.Server
+            $configuration.VMHostName | Should -Be $script:configurationData.AllNodes.VMHostName
+            $configuration.VssName | Should -Be $script:configurationData.AllNodes.StandardSwitchName
+            $configuration.PhysicalNicNames | Should -Be $script:configurationData.AllNodes.PhysicalNetworkAdapterNames
+            $configuration.VMKernelNicNames | Should -Be $script:configurationData.AllNodes.VMKernelNetworkAdapterNames
+            $configuration.PortGroupNames | Should -Be @($script:configurationData.AllNodes.ManagementPortGroupName, $script:configurationData.AllNodes.VMotionPortGroupName)
+        }
+
+        It 'Should return $true when Test-DscConfiguration is run' {
+            # Arrange
+            $testDscConfigurationParameters = @{
+                ReferenceConfiguration = "$script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath\$($script:configurationData.AllNodes.NodeName).mof"
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            (Test-DscConfiguration @testDscConfigurationParameters).InDesiredState | Should -Be $true
+        }
+
+        AfterAll {
+            # Arrange
+            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch `
+                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configRemoveVDSwitchAndStandardSwitch `
+                -OutputPath $script:mofFileRemoveVDSwitchAndStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches `
+                -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch = @{
+                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch = @{
+                Path = $script:mofFileRemoveVDSwitchAndStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = @{
+                Path = $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
+
+            Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveVDSwitchAndStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
+        }
+    }
+}

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
@@ -90,22 +90,26 @@ $script:configurationData = @{
 }
 
 $script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = "$($script:dscResourceName)_CreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch_Config"
-$script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter = "$($script:dscResourceName)_CreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter_Config"
+$script:configCreateManagementAndvMotionVMKernelNetworkAdapters = "$($script:dscResourceName)_CreateManagementAndvMotionVMKernelNetworkAdapters_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToDistributedSwitch_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch_Config"
-$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch = "$($script:dscResourceName)_RemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch_Config"
+$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch_Config"
+$script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch = "$($script:dscResourceName)_RemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch_Config"
+$script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch = "$($script:dscResourceName)_RemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch_Config"
 $script:configRemoveVDSwitchAndStandardSwitch = "$($script:dscResourceName)_RemoveVDSwitchAndStandardSwitch_Config"
 $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = "$($script:dscResourceName)_MigratePhysicalNetworkAdaptersToInitialVirtualSwitches_Config"
 
 . $script:configurationFile -ErrorAction Stop
 
 $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath = "$script:integrationTestsFolderPath\$script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch\"
-$script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath = "$script:integrationTestsFolderPath\$script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter\"
+$script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath = "$script:integrationTestsFolderPath\$script:configCreateManagementAndvMotionVMKernelNetworkAdapters\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch\"
-$script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch\"
+$script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch\"
+$script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch\"
+$script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch\"
 $script:mofFileRemoveVDSwitchAndStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configRemoveVDSwitchAndStandardSwitch\"
 $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath = "$script:integrationTestsFolderPath\$script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches\"
 
@@ -257,8 +261,8 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
-            & $script:configCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter `
-                -OutputPath $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath `
+            & $script:configCreateManagementAndvMotionVMKernelNetworkAdapters `
+                -OutputPath $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
@@ -276,8 +280,8 @@ Describe "$($script:dscResourceName)_Integration" {
                 ErrorAction = 'Stop'
             }
 
-            $startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter = @{
-                Path = $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath
+            $startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters = @{
+                Path = $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -296,7 +300,7 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
-            Start-DscConfiguration @startDscConfigurationParametersCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapter
+            Start-DscConfiguration @startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters
             Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
 
             Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch
@@ -316,6 +320,8 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch
+
+            Get-PortGroupNamesWithVMKernelPrefix
         }
 
         It 'Should apply the MOF without throwing' {
@@ -348,7 +354,7 @@ Describe "$($script:dscResourceName)_Integration" {
             $configuration.VssName | Should -Be $script:configurationData.AllNodes.StandardSwitchName
             $configuration.PhysicalNicNames | Should -Be $script:configurationData.AllNodes.PhysicalNetworkAdapterNames
             $configuration.VMKernelNicNames | Should -Be $script:configurationData.AllNodes.VMKernelNetworkAdapterNames
-            $configuration.PortGroupNames | Should -Be @($script:configurationData.AllNodes.ManagementPortGroupName, $script:configurationData.AllNodes.VMotionPortGroupName)
+            $configuration.PortGroupNames | Should -Be $script:configurationData.AllNodes.PortGroupNamesWithVMKernelPrefix
         }
 
         It 'Should return $true when Test-DscConfiguration is run' {
@@ -366,8 +372,8 @@ Describe "$($script:dscResourceName)_Integration" {
 
         AfterAll {
             # Arrange
-            & $script:configRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch `
-                -OutputPath $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath `
+            & $script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch `
+                -OutputPath $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitchPath `
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
@@ -381,8 +387,8 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
-            $startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch = @{
-                Path = $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath
+            $startDscConfigurationParametersRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch = @{
+                Path = $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitchPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -409,15 +415,189 @@ Describe "$($script:dscResourceName)_Integration" {
             }
 
             # Act
-            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitch
             Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileCreateManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileRemoveManagementVMKernelNetworkAdapterAndvMotionVMKernelNetworkAdapterFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveVDSwitchAndStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
+        }
+    }
+
+    Context "When using configuration $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch" {
+        BeforeAll {
+            # Arrange
+            & $script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch `
+                -OutputPath $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configCreateManagementAndvMotionVMKernelNetworkAdapters `
+                -OutputPath $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = @{
+                Path = $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters = @{
+                Path = $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
+            Start-DscConfiguration @startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
+
+            Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch
+
+            & $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch `
+                -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch
+        }
+
+        It 'Should apply the MOF without throwing' {
+            # Arrange
+            $startDscConfigurationParameters = @{
+                Path = $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            { Start-DscConfiguration @startDscConfigurationParameters } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            # Arrange && Act && Assert
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
+
+        It 'Should be able to call Get-DscConfiguration and all parameters should match' {
+            # Arrange && Act
+            $configuration = Get-DscConfiguration -Verbose -ErrorAction Stop | Where-Object -FilterScript { $_.ConfigurationName -eq $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitch }
+
+            # Assert
+            $configuration.Server | Should -Be $script:configurationData.AllNodes.Server
+            $configuration.VMHostName | Should -Be $script:configurationData.AllNodes.VMHostName
+            $configuration.VssName | Should -Be $script:configurationData.AllNodes.StandardSwitchName
+            $configuration.PhysicalNicNames | Should -Be $script:configurationData.AllNodes.PhysicalNetworkAdapterNames
+            $configuration.VMKernelNicNames | Should -Be $script:configurationData.AllNodes.VMKernelNetworkAdapterNames
+            $configuration.PortGroupNames | Should -Be @($script:configurationData.AllNodes.ManagementPortGroupName, $script:configurationData.AllNodes.VMotionPortGroupName)
+        }
+
+        It 'Should return $true when Test-DscConfiguration is run' {
+            # Arrange
+            $testDscConfigurationParameters = @{
+                ReferenceConfiguration = "$script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath\$($script:configurationData.AllNodes.NodeName).mof"
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act && Assert
+            (Test-DscConfiguration @testDscConfigurationParameters).InDesiredState | Should -Be $true
+        }
+
+        AfterAll {
+            # Arrange
+            & $script:configRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch `
+                -OutputPath $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configRemoveVDSwitchAndStandardSwitch `
+                -OutputPath $script:mofFileRemoveVDSwitchAndStandardSwitchPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            & $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches `
+                -OutputPath $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath `
+                -ConfigurationData $script:configurationData `
+                -ErrorAction Stop
+
+            $startDscConfigurationParametersRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch = @{
+                Path = $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch = @{
+                Path = $script:mofFileRemoveVDSwitchAndStandardSwitchPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            $startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = @{
+                Path = $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath
+                ComputerName = $script:configurationData.AllNodes.NodeName
+                Wait = $true
+                Force = $true
+                Verbose = $true
+                ErrorAction = 'Stop'
+            }
+
+            # Act
+            Start-DscConfiguration @startDscConfigurationParametersRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersRemoveVDSwitchAndStandardSwitch
+            Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
+
+            Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
+            Remove-Item -Path $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveVDSwitchAndStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigratePhysicalNetworkAdaptersToInitialVirtualSwitchesPath -Recurse -Confirm:$false -ErrorAction Stop
         }

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Integration.Tests.ps1
@@ -64,8 +64,6 @@ $script:configurationData = @{
             VMotionStandardPortGroupResourceId = '[VMHostVssPortGroup]VMotionStandardPortGroup'
             VMHostVssResourceName = 'VMHostVss'
             VDSwitchVMHostResourceName = 'VDSwitchVMHost'
-            VMHostVdsManagementNicResourceName = 'VMHostVdsManagementNic'
-            VMHostVdsvMotionNicResourceName = 'VMHostVdsvMotionNic'
             VMHostVDSwitchMigrationResourceName = 'VMHostVDSwitchMigration'
             VMHostVssMigrationResourceName = 'VMHostVssMigration'
             VMHostVssManagementNicResourceName = 'VMHostVssManagementNic'
@@ -79,8 +77,6 @@ $script:configurationData = @{
             ManagementPortGroupName = 'MyManagementPortGroup'
             VMotionPortGroupName = 'MyvMotionPortGroup'
             StandardSwitchName = 'MyTestStandardSwitch'
-            ManagementTrafficEnabled = $true
-            VMotionEnabled = $true
             PhysicalNetworkAdapterNames = $script:physicalNetworkAdapters
             VirtualSwitches = $script:virtualSwitchesWithPhysicalNics
             LinkDiscoveryProtocolOperation = 'Listen'
@@ -90,7 +86,6 @@ $script:configurationData = @{
 }
 
 $script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = "$($script:dscResourceName)_CreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch_Config"
-$script:configCreateManagementAndvMotionVMKernelNetworkAdapters = "$($script:dscResourceName)_CreateManagementAndvMotionVMKernelNetworkAdapters_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToDistributedSwitch_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersToStandardSwitch_Config"
 $script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch = "$($script:dscResourceName)_MigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch_Config"
@@ -103,7 +98,6 @@ $script:configMigratePhysicalNetworkAdaptersToInitialVirtualSwitches = "$($scrip
 . $script:configurationFile -ErrorAction Stop
 
 $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath = "$script:integrationTestsFolderPath\$script:configCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch\"
-$script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath = "$script:integrationTestsFolderPath\$script:configCreateManagementAndvMotionVMKernelNetworkAdapters\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersToStandardSwitch\"
 $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath = "$script:integrationTestsFolderPath\$script:configMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitch\"
@@ -261,11 +255,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
-            & $script:configCreateManagementAndvMotionVMKernelNetworkAdapters `
-                -OutputPath $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch `
                 -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath `
                 -ConfigurationData $script:configurationData `
@@ -273,15 +262,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
             $startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
-
-            $startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters = @{
-                Path = $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -300,7 +280,9 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
-            Start-DscConfiguration @startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters
+
+            New-VMKernelNetworkAdaptersOnDistributedSwitch
+
             Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
 
             Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch
@@ -420,7 +402,6 @@ Describe "$($script:dscResourceName)_Integration" {
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersWithPortGroupsWithVMKernelPrefixFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
@@ -437,11 +418,6 @@ Describe "$($script:dscResourceName)_Integration" {
                 -ConfigurationData $script:configurationData `
                 -ErrorAction Stop
 
-            & $script:configCreateManagementAndvMotionVMKernelNetworkAdapters `
-                -OutputPath $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath `
-                -ConfigurationData $script:configurationData `
-                -ErrorAction Stop
-
             & $script:configMigrateThreePhysicalNetworkAdaptersToDistributedSwitch `
                 -OutputPath $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath `
                 -ConfigurationData $script:configurationData `
@@ -449,15 +425,6 @@ Describe "$($script:dscResourceName)_Integration" {
 
             $startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch = @{
                 Path = $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath
-                ComputerName = $script:configurationData.AllNodes.NodeName
-                Wait = $true
-                Force = $true
-                Verbose = $true
-                ErrorAction = 'Stop'
-            }
-
-            $startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters = @{
-                Path = $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath
                 ComputerName = $script:configurationData.AllNodes.NodeName
                 Wait = $true
                 Force = $true
@@ -476,7 +443,9 @@ Describe "$($script:dscResourceName)_Integration" {
 
             # Act
             Start-DscConfiguration @startDscConfigurationParametersCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitch
-            Start-DscConfiguration @startDscConfigurationParametersCreateManagementAndvMotionVMKernelNetworkAdapters
+
+            New-VMKernelNetworkAdaptersOnDistributedSwitch
+
             Start-DscConfiguration @startDscConfigurationParametersMigrateThreePhysicalNetworkAdaptersToDistributedSwitch
 
             Get-VMKernelNetworkAdapterNamesConnectedToDistributedSwitch
@@ -594,7 +563,6 @@ Describe "$($script:dscResourceName)_Integration" {
             Start-DscConfiguration @startDscConfigurationParametersMigratePhysicalNetworkAdaptersToInitialVirtualSwitches
 
             Remove-Item -Path $script:mofFileCreateVDSwitchTwoVDPortGroupsStandardSwitchAndAddVMHostToVDSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
-            Remove-Item -Path $script:mofFileCreateManagementAndvMotionVMKernelNetworkAdaptersPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersToDistributedSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileMigrateThreePhysicalNetworkAdaptersAndTwoVMKernelNetworkAdaptersWithPortGroupsToStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop
             Remove-Item -Path $script:mofFileRemoveManagementAndvMotionVMKernelNetworkAdaptersFromStandardSwitchPath -Recurse -Confirm:$false -ErrorAction Stop

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/MockData.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/MockData.ps1
@@ -1003,3 +1003,21 @@ $script:vmHostAuthenticationInfoWithDomain = [VMware.VimAutomation.ViCore.Impl.V
     Domain = $script:constants.DomainName
     VMHost = $script:vmHost
 }
+
+$script:standardSwitchWithOnePhysicalNetworkAdapter = [VMware.VimAutomation.ViCore.Impl.V1.Host.Networking.VirtualSwitchImpl] @{
+    Name = $script:constants.VirtualSwitchName
+    VMHost = $script:vmHost
+    Nic = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+}
+
+$script:vmKernelNetworkAdapterToMigrateToStandardSwitch = [VMware.VimAutomation.ViCore.Impl.V1.Host.Networking.Nic.HostVMKernelVirtualNicImpl] @{
+    Name = $script:constants.VMKernelNetworkAdapterOneName
+    VMHost = $script:vmHost
+    PortGroupName = $script:constants.PortGroupOneName
+}
+
+$script:portGroupWithAttachedVMKernelNetworkAdapter = [VMware.VimAutomation.ViCore.Impl.V1.Host.Networking.VirtualPortGroupImpl] @{
+    Name = $script:constants.PortGroupOneName
+    VirtualSwitch = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    VirtualSwitchName = $script:constants.VirtualSwitchName
+}

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVDSwitchMigrationMocks.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVDSwitchMigrationMocks.ps1
@@ -79,10 +79,7 @@ function New-MocksWhenTwoDisconnectedPhysicalNetworkAdaptersArePassedAndServerEr
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.DisconnectedPhysicalNetworkAdapterOneName,
-        $script:constants.DisconnectedPhysicalNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterTwoName)
 
     $physicalNetworkAdapterOneMock = $script:disconnectedPhysicalNetworkAdapterOne
     $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterTwo
@@ -100,10 +97,7 @@ function New-MocksWhenTwoDisconnectedPhysicalNetworkAdaptersArePassed {
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.DisconnectedPhysicalNetworkAdapterOneName,
-        $script:constants.DisconnectedPhysicalNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterTwoName)
 
     $physicalNetworkAdapterOneMock = $script:disconnectedPhysicalNetworkAdapterOne
     $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterTwo
@@ -171,10 +165,7 @@ function New-MocksWhenOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAda
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
     $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -198,10 +189,7 @@ function New-MocksWhenOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAda
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
     $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -225,10 +213,7 @@ function New-MocksWhenOneDisconnectedPhysicalNetworkAdapterTwoVMKernelNetworkAda
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
     $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName, $script:constants.PortGroupTwoName)
 
     $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -253,14 +238,8 @@ function New-MocksWhenTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAd
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.DisconnectedPhysicalNetworkAdapterOneName,
-        $script:constants.DisconnectedPhysicalNetworkAdapterTwoName
-    )
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterTwoName)
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $physicalNetworkAdapterOneMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -285,14 +264,8 @@ function New-MocksWhenTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAd
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.DisconnectedPhysicalNetworkAdapterOneName,
-        $script:constants.DisconnectedPhysicalNetworkAdapterTwoName
-    )
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterTwoName)
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $physicalNetworkAdapterOneMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -317,14 +290,8 @@ function New-MocksWhenTwoDisconnectedPhysicalNetworkAdaptersTwoVMKernelNetworkAd
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.DisconnectedPhysicalNetworkAdapterOneName,
-        $script:constants.DisconnectedPhysicalNetworkAdapterTwoName
-    )
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterTwoName)
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName, $script:constants.PortGroupTwoName)
 
     $physicalNetworkAdapterOneMock = $script:disconnectedPhysicalNetworkAdapterOne
@@ -356,10 +323,7 @@ function New-MocksWhenTwoConnectedAndOneDisconnectedPhysicalNetworkAdaptersTwoVM
         $script:constants.ConnectedPhysicalNetworkAdapterTwoName,
         $script:constants.DisconnectedPhysicalNetworkAdapterOneName
     )
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
@@ -391,10 +355,7 @@ function New-MocksWhenTwoConnectedAndOneDisconnectedPhysicalNetworkAdaptersTwoVM
         $script:constants.ConnectedPhysicalNetworkAdapterTwoName,
         $script:constants.DisconnectedPhysicalNetworkAdapterOneName
     )
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName, $script:constants.PortGroupTwoName)
 
     $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
@@ -456,10 +417,7 @@ function New-MocksWhenTwoPhysicalNetworkAdaptersArePassedAndTheSecondIsNotAddedT
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
-    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @(
-        $script:constants.ConnectedPhysicalNetworkAdapterOneName,
-        $script:constants.ConnectedPhysicalNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.ConnectedPhysicalNetworkAdapterTwoName)
 
     $distributedSwitchMock = $script:distributedSwitchWithAddedPhysicalNetworkAdapters
     $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
@@ -538,10 +496,7 @@ function New-MocksWhenTwoVMKernelNetworkAdaptersAndOnePortGroupArePassedAndTheSe
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
     $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName)
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $distributedSwitchMock = $script:distributedSwitchWithAddedPhysicalNetworkAdapters
@@ -564,10 +519,7 @@ function New-MocksWhenTwoVMKernelNetworkAdaptersAndTwoPortGroupsArePassedAndTheS
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
     $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName)
-    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @(
-        $script:constants.VMKernelNetworkAdapterOneName,
-        $script:constants.VMKernelNetworkAdapterTwoName
-    )
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
     $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName, $script:constants.PortGroupTwoName)
 
     $distributedSwitchMock = $script:distributedSwitchWithAddedPhysicalNetworkAdapters
@@ -589,11 +541,10 @@ function New-MocksInGet {
 
     $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
 
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
+
     $distributedSwitchMock = $script:distributedSwitchWithAddedPhysicalNetworkAdapters
-    $vmKernelNetworkAdaptersMock = @(
-        $script:vmKernelNetworkAdapterOne,
-        $script:vmKernelNetworkAdapterTwo
-    )
+    $vmKernelNetworkAdaptersMock = @($script:vmKernelNetworkAdapterOne, $script:vmKernelNetworkAdapterTwo)
 
     # We need to mock Get-VDSwitch again here to change the Distributed Switch we use in all the other tests.
     Mock -CommandName Get-VDSwitch -MockWith { return $distributedSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DistributedSwitchName } -Verifiable

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVssMigrationMocks.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVssMigrationMocks.ps1
@@ -248,7 +248,7 @@ function New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndItIsAddedToTheStandard
     $vmHostVssMigrationProperties
 }
 
-function New-MocksWhenOneVMKernelNetworkAdapterAndZeroPortGroupsArePassed {
+function New-MocksWhenTwoVMKernelNetworkAdaptersAndOnePortGroupArePassed {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
 
@@ -256,8 +256,28 @@ function New-MocksWhenOneVMKernelNetworkAdapterAndZeroPortGroupsArePassed {
 
     $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
     $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
-    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
-    $vmHostVssMigrationProperties.PortGroupNames = @()
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName, $script:constants.VMKernelNetworkAdapterTwoName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.disconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenZeroVMKernelNetworkAdaptersAndOnePortGroupArePassed {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @()
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
 
     $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
     $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVssMigrationMocks.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVssMigrationMocks.ps1
@@ -1,0 +1,332 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+function New-VMHostVssMigrationProperties {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = @{
+        Server = $script:constants.VIServerName
+        Credential = $script:credential
+        VMHostName = $script:constants.VMHostName
+        VssName = $script:constants.VirtualSwitchName
+    }
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksForVMHostVssMigration {
+    [CmdletBinding()]
+
+    $viServerMock = $script:viServer
+    $vmHostMock = $script:vmHost
+
+    Mock -CommandName Connect-VIServer -MockWith { return $viServerMock }.GetNewClosure() -Verifiable
+    Mock -CommandName Get-VMHost -MockWith { return $vmHostMock }.GetNewClosure() -Verifiable
+    Mock -CommandName Disconnect-VIServer -MockWith { return $null }.GetNewClosure() -Verifiable
+}
+
+function New-MocksWhenServerErrorOccursDuringStandardSwitchRetrieval {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { throw }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenTwoPhysicalNetworkAdaptersArePassedAndServerErrorOccursDuringMigration {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+
+    $standardSwitchMock = $script:virtualSwitch
+    $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
+    $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterOneMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterTwoMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Add-VirtualSwitchPhysicalNetworkAdapter -MockWith { throw }.GetNewClosure() -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenTwoPhysicalNetworkAdaptersArePassedAndBothAreNotAddedToThePassedStandardSwitch {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+
+    $standardSwitchMock = $script:virtualSwitch
+    $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
+    $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterOneMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterTwoMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Add-VirtualSwitchPhysicalNetworkAdapter -MockWith { return $null }.GetNewClosure() -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndServerErrorOccursDuringMigration {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
+    $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterOne
+    $vmKernelNetworkAdapterMock = $script:vmKernelNetworkAdapterOne
+    $standardPortGroupMock = $script:portGroupWithAttachedVMKernelNetworkAdapter
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterOneMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterTwoMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $VMKernel } -Verifiable
+    Mock -CommandName Get-VirtualPortGroup -MockWith { return $standardPortGroupMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupOneName -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $Standard } -Verifiable
+    Mock -CommandName Add-VirtualSwitchPhysicalNetworkAdapter -MockWith { throw }.GetNewClosure() -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedThePortGroupDoesNotExistAndServerErrorOccursDuringPortGroupCreation {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
+    $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterOne
+    $vmKernelNetworkAdapterMock = $script:vmKernelNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterOneMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterTwoMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $VMKernel } -Verifiable
+    Mock -CommandName Get-VirtualPortGroup -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupOneName -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $Standard } -Verifiable
+    Mock -CommandName New-VirtualPortGroup -MockWith { throw }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupOneName -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndThePortGroupDoesNotExist {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName, $script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterOneMock = $script:connectedPhysicalNetworkAdapterOne
+    $physicalNetworkAdapterTwoMock = $script:disconnectedPhysicalNetworkAdapterOne
+    $vmKernelNetworkAdapterMock = $script:vmKernelNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterOneMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterTwoMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $VMKernel } -Verifiable
+    Mock -CommandName Get-VirtualPortGroup -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupOneName -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $Standard } -Verifiable
+    Mock -CommandName New-VirtualPortGroup -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupOneName -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter } -Verifiable
+    Mock -CommandName Add-VirtualSwitchPhysicalNetworkAdapter -MockWith { return $null }.GetNewClosure() -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndIsNotPresentOnTheServer {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterTwoName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+
+    # Mock Write-WarningLog to avoid the warning output when executing the Unit Tests.
+    Mock -CommandName Write-WarningLog -MockWith { return $null }.GetNewClosure() -Verifiable
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterTwoName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndTheStandardSwitchDoesNotHavePhysicalNetworkAdaptersAddedToIt {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName)
+
+    $standardSwitchMock = $script:virtualSwitch
+    $physicalNetworkAdapterMock = $script:connectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndItIsNotAddedToTheStandardSwitch {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.ConnectedPhysicalNetworkAdapterOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:connectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.ConnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndItIsAddedToTheStandardSwitch {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.disconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOneVMKernelNetworkAdapterAndZeroPortGroupsArePassed {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @()
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.disconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndTheVMKernelNetworkAdapterIsNotAddedToTheStandardSwitch {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.disconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $PortGroup -eq $script:constants.PortGroupOneName -and $VMKernel } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksWhenOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndTheVMKernelNetworkAdapterIsAddedToTheStandardSwitch {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+    $vmKernelNetworkAdapterMock = $script:vmKernelNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.disconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNetworkAdapterOneName -and $VMHost -eq $script:vmHost -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $PortGroup -eq $script:constants.PortGroupOneName -and $VMKernel } -Verifiable
+
+    $vmHostVssMigrationProperties
+}
+
+function New-MocksInGet {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVssMigrationProperties = New-VMHostVssMigrationProperties
+
+    $vmHostVssMigrationProperties.VssName = $script:constants.VirtualSwitchName
+    $vmHostVssMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+    $vmHostVssMigrationProperties.PortGroupNames = @($script:constants.PortGroupOneName)
+
+    $standardSwitchMock = $script:standardSwitchWithOnePhysicalNetworkAdapter
+    $vmKernelNetworkAdapterMock = $script:vmKernelNetworkAdapterOne
+
+    Mock -CommandName Get-VirtualSwitch -MockWith { return $standardSwitchMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VirtualSwitchName -and $VMHost -eq $script:vmHost -and $Standard } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $VMHost -eq $script:vmHost -and $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and $VMKernel } -Verifiable
+
+    $vmHostVssMigrationProperties
+}

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/VMware.VimAutomation.Core/VMware.VimAutomation.Core.psm1
@@ -618,7 +618,6 @@ function Add-VirtualSwitchPhysicalNetworkAdapter {
         $VirtualSwitch,
 
         [Parameter(Mandatory = $false, ParameterSetName = "__AllParameterSets", ValueFromPipeline = $false)]
-        [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.VirtualPortGroup[]]
         $VirtualNicPortgroup,
 
         [Parameter(Mandatory = $false, ParameterSetName = "__AllParameterSets", ValueFromPipeline = $false)]

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Unit.Tests.ps1
@@ -122,10 +122,7 @@ InModuleScope -ModuleName $script:moduleName {
 
                 It 'Should throw the correct error when two disconnected Physical Network Adapters are passed and Server error occurs during migration' {
                     # Act && Assert
-                    $vmHostPhysicalNetworkAdaptersToMigrate = @(
-                        $script:disconnectedPhysicalNetworkAdapterOne,
-                        $script:disconnectedPhysicalNetworkAdapterTwo
-                    )
+                    $vmHostPhysicalNetworkAdaptersToMigrate = @($script:disconnectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterTwo)
 
                     # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
                     { $resource.Set() } | Should -Throw "Could not migrate Physical Network Adapters $vmHostPhysicalNetworkAdaptersToMigrate to Distributed Switch $($script:distributedSwitch.Name). For more information: ScriptHalted"
@@ -152,10 +149,7 @@ InModuleScope -ModuleName $script:moduleName {
                     $resource.Set()
 
                     # Assert
-                    $expectedVMHostPhysicalNic = @(
-                        $script:disconnectedPhysicalNetworkAdapterOne,
-                        $script:disconnectedPhysicalNetworkAdapterTwo
-                    )
+                    $expectedVMHostPhysicalNic = @($script:disconnectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterTwo)
 
                     $assertMockCalledParams = @{
                         CommandName = 'Add-VDSwitchPhysicalNetworkAdapter'
@@ -194,10 +188,7 @@ InModuleScope -ModuleName $script:moduleName {
 
                 It 'Should throw the correct error when two connected and one disconnected Physical Network Adapters are passed and Server error occurs during migration' {
                     # Act && Assert
-                    $vmHostPhysicalNetworkAdaptersToMigrate = @(
-                        $script:connectedPhysicalNetworkAdapterTwo,
-                        $script:disconnectedPhysicalNetworkAdapterOne
-                    )
+                    $vmHostPhysicalNetworkAdaptersToMigrate = @($script:connectedPhysicalNetworkAdapterTwo, $script:disconnectedPhysicalNetworkAdapterOne)
 
                     # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
                     { $resource.Set() } | Should -Throw "Could not migrate Physical Network Adapters $vmHostPhysicalNetworkAdaptersToMigrate to Distributed Switch $($script:distributedSwitch.Name). For more information: ScriptHalted"
@@ -247,10 +238,7 @@ InModuleScope -ModuleName $script:moduleName {
                     $resource.Set()
 
                     # Assert
-                    $expectedVMHostPhysicalNic = @(
-                        $script:connectedPhysicalNetworkAdapterTwo,
-                        $script:disconnectedPhysicalNetworkAdapterOne
-                    )
+                    $expectedVMHostPhysicalNic = @($script:connectedPhysicalNetworkAdapterTwo, $script:disconnectedPhysicalNetworkAdapterOne)
 
                     $assertMockCalledParams = @{
                         CommandName = 'Add-VDSwitchPhysicalNetworkAdapter'

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Unit.Tests.ps1
@@ -328,10 +328,10 @@ InModuleScope -ModuleName $script:moduleName {
                 }
             }
 
-            Context 'One VMKernel Network Adapter and zero Port Groups are passed' {
+            Context 'Two VMKernel Network Adapters and one Port Group are passed' {
                 BeforeAll {
                     # Arrange
-                    $resourceProperties = New-MocksWhenOneVMKernelNetworkAdapterAndZeroPortGroupsArePassed
+                    $resourceProperties = New-MocksWhenTwoVMKernelNetworkAdaptersAndOnePortGroupArePassed
                     $resource = New-Object -TypeName $resourceName -Property $resourceProperties
                 }
 
@@ -346,7 +346,31 @@ InModuleScope -ModuleName $script:moduleName {
                     }
                 }
 
-                It 'Should throw the correct error when one VMKernel Network Adapter and zero Port Groups are passed' {
+                It 'Should throw the correct error when two VMKernel Network Adapters and one Port Group are passed' {
+                    # Act && Assert
+                    { $resource.Test() } | Should -Throw "$($resourceProperties.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($resourceProperties.PortGroupNames.Length) Port Groups specified which is not valid."
+                }
+            }
+
+            Context 'Zero VMKernel Network Adapters and one Port Group are passed' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenZeroVMKernelNetworkAdaptersAndOnePortGroupArePassed
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Test()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when zero VMKernel Network Adapters and one Port Group are passed' {
                     # Act && Assert
                     { $resource.Test() } | Should -Throw "$($resourceProperties.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($resourceProperties.PortGroupNames.Length) Port Groups specified which is not valid."
                 }

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVssMigration.Unit.Tests.ps1
@@ -1,0 +1,443 @@
+<#
+Copyright (c) 2018 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+Using module VMware.vSphereDSC
+
+$script:moduleName = 'VMware.vSphereDSC'
+
+InModuleScope -ModuleName $script:moduleName {
+    try {
+        $unitTestsFolder = Join-Path (Join-Path (Get-Module VMware.vSphereDSC -ListAvailable).ModuleBase 'Tests') 'Unit'
+        $modulePath = $env:PSModulePath
+        $resourceName = 'VMHostVssMigration'
+
+        . "$unitTestsFolder\TestHelpers\TestUtils.ps1"
+
+        # Calls the function to Import the mocked VMware.VimAutomation.Core module before all tests.
+        Invoke-TestSetup
+
+        . "$unitTestsFolder\TestHelpers\Mocks\MockData.ps1"
+        . "$unitTestsFolder\TestHelpers\Mocks\VMHostVssMigrationMocks.ps1"
+
+        Describe 'VMHostVssMigration\Set' -Tag 'Set' {
+            BeforeAll {
+                # Arrange
+                New-MocksForVMHostVssMigration
+            }
+
+            Context 'Server error occurs during Standard Switch retrieval' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenServerErrorOccursDuringStandardSwitchRetrieval
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Set()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when Server error occurs during Standard Switch retrieval' {
+                    # Act && Assert
+                    # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
+                    { $resource.Set() } | Should -Throw "Could not retrieve Standard Switch $($resourceProperties.VssName). For more information: ScriptHalted"
+                }
+            }
+
+            Context 'Two Physical Network Adapters are passed and Server error occurs during migration' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenTwoPhysicalNetworkAdaptersArePassedAndServerErrorOccursDuringMigration
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Set()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when two Physical Network Adapters are passed and Server error occurs during migration' {
+                    # Act && Assert
+                    $vmHostPhysicalNetworkAdaptersToMigrate = @($script:connectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterOne)
+
+                    # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
+                    { $resource.Set() } | Should -Throw "Could not migrate Physical Network Adapters $vmHostPhysicalNetworkAdaptersToMigrate to Standard Switch $($script:virtualSwitch.Name). For more information: ScriptHalted"
+                }
+            }
+
+            Context 'Two Physical Network Adapters are passed and both are not added the the passed Standard Switch' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenTwoPhysicalNetworkAdaptersArePassedAndBothAreNotAddedToThePassedStandardSwitch
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should call the Add-VirtualSwitchPhysicalNetworkAdapter mock with the Standard Switch and the two passed Physical Network Adapters once' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    $expectedVMHostPhysicalNic = @($script:connectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterOne)
+
+                    $assertMockCalledParams = @{
+                        CommandName = 'Add-VirtualSwitchPhysicalNetworkAdapter'
+                        ParameterFilter = {
+                            $Server -eq $script:viServer -and
+                            $VirtualSwitch -eq $script:virtualSwitch -and
+                            [System.Linq.Enumerable]::SequenceEqual($VMHostPhysicalNic, [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.Nic.PhysicalNic[]] $expectedVMHostPhysicalNic) -and
+                            !$Confirm
+                        }
+                        Exactly = $true
+                        Times = 1
+                        Scope = 'It'
+                    }
+
+                    Assert-MockCalled @assertMockCalledParams
+                }
+            }
+
+            Context 'Two Physical Network Adapters, One VMKernel Network Adapter and One Port Group are passed and Server error occurs during migration' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndServerErrorOccursDuringMigration
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Set()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when two Physical Network Adapters, One VMKernel Network Adapter and One Port Group are passed and Server error occurs during migration' {
+                    # Act && Assert
+                    $vmHostPhysicalNetworkAdaptersToMigrate = @($script:connectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterOne)
+                    $vmHostVMKernelNetworkAdaptersToMigrate = @($script:vmKernelNetworkAdapterOne)
+
+                    # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
+                    { $resource.Set() } | Should -Throw "Could not migrate Physical Network Adapters $vmHostPhysicalNetworkAdaptersToMigrate and VMKernel Network Adapters $vmHostVMKernelNetworkAdaptersToMigrate to Standard Switch $($script:standardSwitchWithOnePhysicalNetworkAdapter.Name). For more information: ScriptHalted"
+                }
+            }
+
+            Context 'Two Physical Network Adapters, One VMKernel Network Adapter and One Port Group are passed, the Port Group does not exist and Server error occurs during Port Group creation' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedThePortGroupDoesNotExistAndServerErrorOccursDuringPortGroupCreation
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Set()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when two Physical Network Adapters, One VMKernel Network Adapter and One Port Group are passed, the Port Group does not exist and Server error occurs during Port Group creation' {
+                    # Act && Assert
+                    # When the Throw statement does not appear in a Catch block, and it does not include an expression, it generates a ScriptHalted error.
+                    { $resource.Set() } | Should -Throw "Cannot create Standard Port Group $($script:constants.PortGroupOneName) on Standard Switch $($script:standardSwitchWithOnePhysicalNetworkAdapter.Name). For more information: ScriptHalted"
+                }
+            }
+
+            Context 'Two Physical Network Adapters, One VMKernel Network Adapter and One Port Group are passed and the Port Group does not exist' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenTwoPhysicalNetworkAdaptersOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndThePortGroupDoesNotExist
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should call the Add-VirtualSwitchPhysicalNetworkAdapter mock with the Standard Switch, the first passed Physical Network Adapter, the VMKernel Network Adapter and Port Group once' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    $expectedVMHostPhysicalNic = @($script:connectedPhysicalNetworkAdapterOne, $script:disconnectedPhysicalNetworkAdapterOne)
+                    $expectedVMHostVirtualNic = @($script:vmKernelNetworkAdapterOne)
+                    $expectedVirtualNicPortgroup = @($script:constants.PortGroupOneName)
+
+                    $assertMockCalledParams = @{
+                        CommandName = 'Add-VirtualSwitchPhysicalNetworkAdapter'
+                        ParameterFilter = {
+                            $Server -eq $script:viServer -and
+                            $VirtualSwitch -eq $script:standardSwitchWithOnePhysicalNetworkAdapter -and
+                            [System.Linq.Enumerable]::SequenceEqual($VMHostPhysicalNic, [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.Nic.PhysicalNic[]] $expectedVMHostPhysicalNic) -and
+                            [System.Linq.Enumerable]::SequenceEqual($VMHostVirtualNic, [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.Nic.HostVirtualNic[]] $expectedVMHostVirtualNic) -and
+                            [System.Linq.Enumerable]::SequenceEqual($VirtualNicPortgroup, [string[]] $expectedVirtualNicPortgroup) -and
+                            !$Confirm
+                        }
+                        Exactly = $true
+                        Times = 1
+                        Scope = 'It'
+                    }
+
+                    Assert-MockCalled @assertMockCalledParams
+                }
+            }
+        }
+
+        Describe 'VMHostVssMigration\Test' -Tag 'Test' {
+            BeforeAll {
+                # Arrange
+                New-MocksForVMHostVssMigration
+            }
+
+            Context 'One Physical Network Adapter is passed and is not present on the Server' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndIsNotPresentOnTheServer
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Test()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when one Physical Network Adapter is passed and is not present on the Server' {
+                    # Act && Assert
+                    { $resource.Test() } | Should -Throw "At least one Physical Network Adapter needs to be specified."
+                }
+            }
+
+            Context 'One Physical Network Adapter is passed and the Standard Switch does not have Physical Network Adapters added to it' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndTheStandardSwitchDoesNotHavePhysicalNetworkAdaptersAddedToIt
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Test()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should return $false when one Physical Network Adapter is passed and the Standard Switch does not have Physical Network Adapters added to it' {
+                    # Act
+                    $result = $resource.Test()
+
+                    # Assert
+                    $result | Should -Be $false
+                }
+            }
+
+            Context 'One Physical Network Adapter is passed and it is not added to the Standard Switch' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndItIsNotAddedToTheStandardSwitch
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Test()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should return $false when one Physical Network Adapter is passed and it is not added to the Standard Switch' {
+                    # Act
+                    $result = $resource.Test()
+
+                    # Assert
+                    $result | Should -Be $false
+                }
+            }
+
+            Context 'One Physical Network Adapter is passed and it is added to the Standard Switch' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOnePhysicalNetworkAdapterIsPassedAndItIsAddedToTheStandardSwitch
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Test()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should return $true when one Physical Network Adapter is passed and it is added to the Standard Switch' {
+                    # Act
+                    $result = $resource.Test()
+
+                    # Assert
+                    $result | Should -Be $true
+                }
+            }
+
+            Context 'One VMKernel Network Adapter and zero Port Groups are passed' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOneVMKernelNetworkAdapterAndZeroPortGroupsArePassed
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    try {
+                        # Act
+                        $resource.Test()
+                    }
+                    catch {
+                        # Assert
+                        Assert-VerifiableMock
+                    }
+                }
+
+                It 'Should throw the correct error when one VMKernel Network Adapter and zero Port Groups are passed' {
+                    # Act && Assert
+                    { $resource.Test() } | Should -Throw "$($resourceProperties.VMKernelNicNames.Length) VMKernel Network Adapters specified and $($resourceProperties.PortGroupNames.Length) Port Groups specified which is not valid."
+                }
+            }
+
+            Context 'One VMKernel Network Adapter and one Port Group are passed and the VMKernel Network Adapter is not added to the Standard Switch' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndTheVMKernelNetworkAdapterIsNotAddedToTheStandardSwitch
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Test()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should return $false when one VMKernel Network Adapter and one Port Group are passed and the VMKernel Network Adapter is not added to the Standard Switch' {
+                    # Act
+                    $result = $resource.Test()
+
+                    # Assert
+                    $result | Should -Be $false
+                }
+            }
+
+            Context 'One VMKernel Network Adapter and one Port Group are passed and the VMKernel Network Adapter is added to the Standard Switch' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenOneVMKernelNetworkAdapterAndOnePortGroupArePassedAndTheVMKernelNetworkAdapterIsAddedToTheStandardSwitch
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Test()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should return $true when one VMKernel Network Adapter and one Port Group are passed and the VMKernel Network Adapter is added to the Standard Switch' {
+                    # Act
+                    $result = $resource.Test()
+
+                    # Assert
+                    $result | Should -Be $true
+                }
+            }
+        }
+
+        Describe 'VMHostVssMigration\Get' -Tag 'Get' {
+            BeforeAll {
+                # Arrange
+                New-MocksForVMHostVssMigration
+
+                $resourceProperties = New-MocksInGet
+                $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+            }
+
+            It 'Should call all defined mocks with the correct parameters' {
+                # Act
+                $resource.Get()
+
+                # Assert
+                Assert-VerifiableMock
+            }
+
+            It 'Should retrieve the Resource properties from the Server' {
+                # Act
+                $result = $resource.Get()
+
+                # Assert
+                $expectedPhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+                $expectedVMKernelNicNames = @($script:constants.VMKernelNetworkAdapterOneName)
+                $expectedPortGroupNames = @($script:constants.PortGroupOneName)
+
+                $result.Server | Should -Be $script:viServer.Name
+                $result.VMHostName | Should -Be $script:vmHost.Name
+                $result.VssName | Should -Be $script:standardSwitchWithOnePhysicalNetworkAdapter.Name
+                $result.PhysicalNicNames | Should -Be $expectedPhysicalNicNames
+                $result.VMKernelNicNames | Should -Be $expectedVMKernelNicNames
+                $result.PortGroupNames | Should -Be $expectedPortGroupNames
+            }
+        }
+    }
+    finally {
+        # Calls the function to Remove the mocked VMware.VimAutomation.Core module after all tests.
+        Invoke-TestCleanup -ModulePath $modulePath
+    }
+}


### PR DESCRIPTION
### Added
- Introduced VMHostNetworkMigrationBaseDSC class.
- Added VMHostVssMigration DSC Resource.
- Added Unit Tests for VMHostVssMigration DSC Resource.
- Added Integration Tests for VMHostVssMigration DSC Resource.
- Added Documentation and example Configurations for VMHostVssMigration DSC Resource.

### Changed
- Modified Get() method of VMHostVDSwitchMigration DSC Resource to retrieve only the passed VMKernel Network Adapters connected to the VDSwitch.

### Removed
- Removed filtration of Physical Network Adapters in VMHostVDSwitchMigration DSC Resource.
