### PR TITLE
Export VMHost DSC Configuration

### DIFF
--- a/Documentation/DSCResources/VMHostCache/VMHostCache.md
+++ b/Documentation/DSCResources/VMHostCache/VMHostCache.md
@@ -7,7 +7,7 @@
 | **Server** | Key | string | Name of the Server we are trying to connect to. The Server can be a vCenter or ESXi. ||
 | **Name** | Key | string | Name of the VMHost to configure. ||
 | **Credential** | Mandatory | PSCredential | Credentials needed for connection to the specified Server. ||
-| **Datastore** | Key | string | The Datastore used for swap performance enhancement. ||
+| **DatastoreName** | Key | string | The name of the Datastore used for swap performance enhancement. ||
 | **SwapSizeGB** | Mandatory | double | The space to allocate on the specified Datastore to implement swap performance enhancements, in GB. This value should be less than or equal to the free space capacity of the Datastore. ||
 
 ## Description
@@ -46,7 +46,7 @@ Configuration VMHostCache_Config {
             Name = $Name
             Server = $Server
             Credential = $Credential
-            Datastore = 'MyDatastore'
+            DatastoreName = 'MyDatastore'
             SwapSizeGB = 1
         }
     }

--- a/Documentation/DSCResources/VMHostVMKernelDumpFile/VMHostVMKernelDumpFile.md
+++ b/Documentation/DSCResources/VMHostVMKernelDumpFile/VMHostVMKernelDumpFile.md
@@ -7,8 +7,8 @@
 | **Server** | Key | string | The name of the Server we are trying to connect to. The Server can be a vCenter or ESXi. ||
 | **Credential** | Mandatory | PSCredential | The credentials needed for connection to the specified Server. ||
 | **Name** | Key | string | The name of the VMHost. ||
-| **DatastoreName** | Mandatory | string | The name of the datastore for the dump file. ||
-| **FileName** | Mandatory | string | The file name of the dump file. ||
+| **DatastoreName** | Key | string | The name of the datastore for the dump file. ||
+| **FileName** | Key | string | The file name of the dump file. ||
 | **Ensure** | Mandatory | Ensure | Specifies whether the VMKernel dump Vmfs file should be present or absent. ||
 | **Size** | Optional | long | The size in MB of the dump file. If not provided, a default size for the current machine is calculated. ||
 | **Force** | Optional | bool | Specifies whether to deactivate and unconfigure the dump file being removed. This option is required if the file is active. ||

--- a/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostCache_Config.ps1
+++ b/Source/VMware.vSphereDSC/Configurations/PowerShell/ESXiConfigs/VMHostCache_Config.ps1
@@ -56,7 +56,7 @@ Configuration VMHostCache_Config {
             Name = $Name
             Server = $Server
             Credential = $Credential
-            Datastore = 'MyDatastore'
+            DatastoreName = 'MyDatastore'
             SwapSizeGB = 1
         }
     }

--- a/Source/VMware.vSphereDSC/DSCResources/EsxCli/VMHostSNMPAgent.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/EsxCli/VMHostSNMPAgent.ps1
@@ -237,7 +237,7 @@ class VMHostSNMPAgent : EsxCliBaseDSC {
         $shouldModifyVMHostSNMPAgent += (![string]::IsNullOrEmpty($this.Hwsrc) -and $this.Hwsrc -ne $esxCliGetMethodResult.hwsrc)
         $shouldModifyVMHostSNMPAgent += ($null -ne $this.LargeStorage -and $this.LargeStorage -ne [System.Convert]::ToBoolean($esxCliGetMethodResult.largestorage))
         $shouldModifyVMHostSNMPAgent += (![string]::IsNullOrEmpty($this.LogLevel) -and $this.LogLevel -ne $esxCliGetMethodResult.loglevel)
-        $shouldModifyVMHostSNMPAgent += ($null -ne $this.NoTraps -and $this.NoTraps -ne $esxCliGetMethodResult.notraps)
+        $shouldModifyVMHostSNMPAgent += ($null -ne $this.NoTraps -and $this.NoTraps -ne [string] $esxCliGetMethodResult.notraps)
         $shouldModifyVMHostSNMPAgent += ($null -ne $this.Port -and $this.Port -ne [int] $esxCliGetMethodResult.port)
         $shouldModifyVMHostSNMPAgent += (![string]::IsNullOrEmpty($this.Privacy) -and $this.Privacy -ne $esxCliGetMethodResult.privacy)
         $shouldModifyVMHostSNMPAgent += (![string]::IsNullOrEmpty($this.RemoteUsers) -and $this.RemoteUsers -ne $esxCliGetMethodResult.remoteusers)

--- a/Source/VMware.vSphereDSC/DSCResources/EsxCli/VMHostVMKernelDumpFile.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/EsxCli/VMHostVMKernelDumpFile.ps1
@@ -25,7 +25,7 @@ class VMHostVMKernelDumpFile : EsxCliBaseDSC {
 
     Specifies the name of the Datastore for the dump file.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty(Key)]
     [string] $DatastoreName
 
     <#
@@ -33,7 +33,7 @@ class VMHostVMKernelDumpFile : EsxCliBaseDSC {
 
     Specifies the file name of the dump file.
     #>
-    [DscProperty(Mandatory)]
+    [DscProperty(Key)]
     [string] $FileName
 
     <#

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostCache.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostCache.ps1
@@ -19,10 +19,10 @@ class VMHostCache : VMHostBaseDSC {
     <#
     .DESCRIPTION
 
-    Specifies the Datastore used for swap performance enhancement.
+    Specifies the name of the Datastore used for swap performance enhancement.
     #>
     [DscProperty(Key)]
-    [string] $Datastore
+    [string] $DatastoreName
 
     <#
     .DESCRIPTION
@@ -100,11 +100,11 @@ class VMHostCache : VMHostBaseDSC {
     #>
     [PSObject] GetDatastore($vmHost) {
         try {
-            $foundDatastore = Get-Datastore -Server $this.Connection -Name $this.Datastore -RelatedObject $vmHost -ErrorAction Stop
+            $foundDatastore = Get-Datastore -Server $this.Connection -Name $this.DatastoreName -RelatedObject $vmHost -ErrorAction Stop
             return $foundDatastore
         }
         catch {
-            throw "Could not retrieve Datastore $($this.Datastore) for VMHost $($this.Name). For more information: $($_.Exception.Message)"
+            throw "Could not retrieve Datastore $($this.DatastoreName) for VMHost $($this.Name). For more information: $($_.Exception.Message)"
         }
     }
 
@@ -200,7 +200,7 @@ class VMHostCache : VMHostBaseDSC {
         $foundDatastore = $this.GetDatastore($vmHost)
         $datastoreCacheInfo = $this.GetDatastoreCacheInfo($vmHostCacheConfigurationManager, $foundDatastore)
 
-        $result.Datastore = $foundDatastore.Name
+        $result.DatastoreName = $foundDatastore.Name
         $result.SwapSizeGB = $this.ConvertMBValueToGBValue($datastoreCacheInfo.SwapSize)
     }
 }

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostSyslog.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostSyslog.ps1
@@ -154,16 +154,16 @@ class VMHostSyslog : VMHostBaseDSC {
 
         $shouldUpdateVMHostSyslog = @()
 
-        $shouldUpdateVMHostSyslog += ![string]::IsNullOrEmpty($this.LogHost) -or ($current.RemoteHost -ne '<none>' -and $this.LogHost -ne $current.RemoteHost)
-        $shouldUpdateVMHostSyslog += $this.CheckSslCerts -ne $current.EnforceSSLCertificates
-        $shouldUpdateVMHostSyslog += $this.DefaultTimeout -ne $current.DefaultNetworkRetryTimeout
-        $shouldUpdateVMHostSyslog += $this.QueueDropMark -ne $current.MessageQueueDropMark
-        $shouldUpdateVMHostSyslog += $this.Logdir -ne $current.LocalLogOutput
-        $shouldUpdateVMHostSyslog += $this.LogdirUnique -ne [System.Convert]::ToBoolean($current.LogToUniqueSubdirectory)
-        $shouldUpdateVMHostSyslog += $this.DefaultRotate -ne $current.LocalLoggingDefaultRotations
-        $shouldUpdateVMHostSyslog += $this.DefaultSize -ne $current.LocalLoggingDefaultRotationSize
-        $shouldUpdateVMHostSyslog += $this.DropLogRotate -ne $current.DroppedLogFileRotations
-        $shouldUpdateVMHostSyslog += $this.DropLogSize -ne $current.DroppedLogFileRotationSize
+        $shouldUpdateVMHostSyslog += (![string]::IsNullOrEmpty($this.LogHost) -and $this.LogHost -ne $current.RemoteHost)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.CheckSslCerts -and $this.CheckSslCerts -ne $current.EnforceSSLCertificates)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.DefaultTimeout -and $this.DefaultTimeout -ne $current.DefaultNetworkRetryTimeout)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.QueueDropMark -and $this.QueueDropMark -ne $current.MessageQueueDropMark)
+        $shouldUpdateVMHostSyslog += (![string]::IsNullOrEmpty($this.Logdir) -and $this.Logdir -ne $current.LocalLogOutput)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.LogdirUnique -and $this.LogdirUnique -ne [System.Convert]::ToBoolean($current.LogToUniqueSubdirectory))
+        $shouldUpdateVMHostSyslog += ($null -ne $this.DefaultRotate -and $this.DefaultRotate -ne $current.LocalLoggingDefaultRotations)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.DefaultSize -and $this.DefaultSize -ne $current.LocalLoggingDefaultRotationSize)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.DropLogRotate -and $this.DropLogRotate -ne $current.DroppedLogFileRotations)
+        $shouldUpdateVMHostSyslog += ($null -ne $this.DropLogSize -and $this.DropLogSize -ne $current.DroppedLogFileRotationSize)
 
         return ($shouldUpdateVMHostSyslog -contains $true)
     }
@@ -178,23 +178,21 @@ class VMHostSyslog : VMHostBaseDSC {
 
         $esxcli = Get-Esxcli -Server $this.Connection -VMHost $vmHost -V2
 
-        $VMHostSyslogConfig = @{
-            checksslcerts = $this.CheckSslCerts
-            defaulttimeout = $this.DefaultTimeout
+        $vmHostSyslogConfig = @{
             queuedropmark = $this.QueueDropMark
-            logdir = $this.Logdir
-            logdirunique = $this.LogdirUnique
             defaultrotate = $this.DefaultRotate
-            defaultsize = $this.DefaultSize
             droplogrotate = $this.DropLogRotate
-            droplogsize = $this.DropLogSize
         }
 
-        if (![string]::IsNullOrEmpty($this.LogHost)) {
-            $VMHostSyslogConfig.loghost = $this.Loghost
-        }
+        if ($null -ne $this.CheckSslCerts) { $vmHostSyslogConfig.checksslcerts = $this.CheckSslCerts }
+        if ($null -ne $this.DefaultTimeout) { $vmHostSyslogConfig.defaulttimeout = $this.DefaultTimeout }
+        if (![string]::IsNullOrEmpty($this.Logdir)) { $vmHostSyslogConfig.logdir = $this.Logdir }
+        if ($null -ne $this.LogdirUnique) { $vmHostSyslogConfig.logdirunique = $this.LogdirUnique }
+        if ($null -ne $this.DefaultSize) { $vmHostSyslogConfig.defaultsize = $this.DefaultSize }
+        if ($null -ne $this.DropLogSize) { $vmHostSyslogConfig.droplogsize = $this.DropLogSize }
+        if (![string]::IsNullOrEmpty($this.LogHost)) { $vmHostSyslogConfig.loghost = $this.Loghost }
 
-        Set-VMHostSyslogConfig -EsxCli $esxcli -VMHostSyslogConfig $VMHostSyslogConfig
+        Set-VMHostSyslogConfig -EsxCli $esxcli -VMHostSyslogConfig $vmHostSyslogConfig
     }
 
     <#
@@ -211,14 +209,14 @@ class VMHostSyslog : VMHostBaseDSC {
         $syslog.Server = $this.Server
         $syslog.Name = $VMHost.Name
         $syslog.Loghost = $currentVMHostSyslog.RemoteHost
-        $syslog.CheckSslCerts = $currentVMHostSyslog.EnforceSSLCertificates
-        $syslog.DefaultTimeout = $currentVMHostSyslog.DefaultNetworkRetryTimeout
-        $syslog.QueueDropMark = $currentVMHostSyslog.MessageQueueDropMark
+        $syslog.CheckSslCerts = [System.Convert]::ToBoolean($currentVMHostSyslog.EnforceSSLCertificates)
+        $syslog.DefaultTimeout = [long] $currentVMHostSyslog.DefaultNetworkRetryTimeout
+        $syslog.QueueDropMark = [long] $currentVMHostSyslog.MessageQueueDropMark
         $syslog.Logdir = $currentVMHostSyslog.LocalLogOutput
         $syslog.LogdirUnique = [System.Convert]::ToBoolean($currentVMHostSyslog.LogToUniqueSubdirectory)
-        $syslog.DefaultRotate = $currentVMHostSyslog.LocalLoggingDefaultRotations
-        $syslog.DefaultSize = $currentVMHostSyslog.LocalLoggingDefaultRotationSize
-        $syslog.DropLogRotate = $currentVMHostSyslog.DroppedLogFileRotations
-        $syslog.DropLogSize = $currentVMHostSyslog.DroppedLogFileRotationSize
+        $syslog.DefaultRotate = [long] $currentVMHostSyslog.LocalLoggingDefaultRotations
+        $syslog.DefaultSize = [long] $currentVMHostSyslog.LocalLoggingDefaultRotationSize
+        $syslog.DropLogRotate = [long] $currentVMHostSyslog.DroppedLogFileRotations
+        $syslog.DropLogSize = [long] $currentVMHostSyslog.DroppedLogFileRotationSize
     }
 }

--- a/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
+++ b/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
@@ -1,0 +1,183 @@
+<#
+Copyright (c) 2018-2020 VMware, Inc.  All rights reserved
+
+The BSD-2 license (the "License") set forth below applies to all parts of the Desired State Configuration Resources for VMware project.  You may not use this file except in compliance with the License.
+
+BSD-2 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#>
+
+using module VMware.vSphereDSC
+
+Param(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $Server,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNull()]
+    [System.Management.Automation.PSCredential]
+    $Credential,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $VMHostName,
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $OutputPath
+)
+
+$script:viServer = $null
+$script:vmHost = $null
+$script:vmHostConfigurationName = "VMHost_Config"
+$script:vmHostConfigurationFileName = $script:vmHostConfigurationName + '_' + (Get-Date -Format 'yyyy-MM-dd') + '.ps1'
+$script:vmHostDscConfigContent = New-Object -TypeName 'System.Text.StringBuilder'
+
+<#
+.DESCRIPTION
+
+Imports the required modules that are needed for extracting the DSC Configuration of the specified VMHost.
+#>
+function Import-RequiredModules {
+    <#
+        The Verbose logic here is needed to suppress the Verbose output of the Import-Module cmdlet
+        when importing the 'VMware.VimAutomation.Core' Module.
+    #>
+    $savedVerbosePreference = $global:VerbosePreference
+    $global:VerbosePreference = 'SilentlyContinue'
+
+    Import-Module -Name VMware.VimAutomation.Core
+
+    $global:VerbosePreference = $savedVerbosePreference
+}
+
+<#
+.DESCRIPTION
+
+Connects to the specified vSphere Server with the passed Credentials.
+#>
+function Connect-VSphereServer {
+    try {
+        Write-Host "Connecting to vSphere Server $Server..." -BackgroundColor DarkGreen -ForegroundColor White
+        Connect-VIServer -Server $Server -Credential $Credential -ErrorAction Stop -Verbose:$false
+    }
+    catch {
+        throw "Cannot establish connection to vSphere Server $Server. For more information: $($_.Exception.Message)"
+    }
+}
+
+<#
+.DESCRIPTION
+
+Retrieves the VMHost with the specified name from the specified vSphere Server.
+#>
+function Get-VSphereVMHost {
+    try {
+        Write-Host "Retrieving VMHost $VMHostName from vSphere Server $($script:viServer.Name)..." -BackgroundColor DarkGreen -ForegroundColor White
+        Get-VMHost -Server $script:viServer -Name $VMHostName -ErrorAction Stop -Verbose:$false
+    }
+    catch {
+        throw "Could not retrieve VMHost $VMHostName from vSphere Server $($script:viServer.Name). For more information: $($_.Exception.Message)"
+    }
+}
+
+<#
+.DESCRIPTION
+
+Closes the last open connection to the specified vSphere Server.
+#>
+function Disconnect-VSphereServer {
+    try {
+        Write-Host "Closing connection to vSphere Server $($script:viServer.Name)..." -BackgroundColor DarkGreen -ForegroundColor White
+        Disconnect-VIServer -Server $script:viServer -Confirm:$false -ErrorAction Stop -Verbose:$false
+    }
+    catch {
+        throw "Cannot close connection to vSphere Server $($script:viServer.Name). For more information: $($_.Exception.Message)"
+    }
+}
+
+<#
+.DESCRIPTION
+
+Sets the parameters for the VMHost DSC Configuration - Server, Credential and VMHostNames.
+#>
+function Set-ConfigurationParameters {
+    [void] $script:vmHostDscConfigContent.Append("Param(`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [Parameter(Mandatory = `$true)]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [ValidateNotNullOrEmpty()]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [string]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    `$Server,`r`n`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [Parameter(Mandatory = `$true)]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [ValidateNotNull()]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [System.Management.Automation.PSCredential]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    `$Credential,`r`n`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [Parameter(Mandatory = `$true)]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [ValidateNotNullOrEmpty()]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    [string[]]`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    `$VMHostNames`r`n")
+    [void] $script:vmHostDscConfigContent.Append(")`r`n`r`n")
+}
+
+<#
+.DESCRIPTION
+
+Sets the DSC Configuration Data for the VMHost DSC Configuration.
+#>
+function Set-ConfigurationData {
+    [void] $script:vmHostDscConfigContent.Append("`$script:configurationData = @{`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    AllNodes = @(`r`n")
+    [void] $script:vmHostDscConfigContent.Append("        @{`r`n")
+    [void] $script:vmHostDscConfigContent.Append("            NodeName = 'localhost'`r`n")
+    [void] $script:vmHostDscConfigContent.Append("            PSDscAllowPlainTextPassword = `$true`r`n")
+    [void] $script:vmHostDscConfigContent.Append("            Server = `$Server`r`n")
+    [void] $script:vmHostDscConfigContent.Append("            Credential = `$Credential`r`n")
+    [void] $script:vmHostDscConfigContent.Append("            VMHostNames = `$VMHostNames`r`n")
+    [void] $script:vmHostDscConfigContent.Append("        }`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    )`r`n")
+    [void] $script:vmHostDscConfigContent.Append("}`r`n`r`n")
+}
+
+<#
+.DESCRIPTION
+
+The main function for extracting the VMHost DSC Configuration. It acts as a call dispatcher, calling all required functions
+in the proper order to get the full Configuration.
+#>
+function Export-VMHostConfiguration {
+    Import-RequiredModules
+    $script:viServer = Connect-VSphereServer
+    $script:vmHost = Get-VSphereVMHost
+
+    Set-ConfigurationParameters
+    Set-ConfigurationData
+
+    [void] $script:vmHostDscConfigContent.Append("Configuration $script:vmHostConfigurationName {`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    Import-DscResource -ModuleName VMware.vSphereDSC`r`n`r`n")
+    [void] $script:vmHostDscConfigContent.Append("    Node `$AllNodes.NodeName {`r`n")
+    [void] $script:vmHostDscConfigContent.Append("        foreach (`$vmHostName in `$AllNodes.VMHostNames) {`r`n")
+
+    [void] $script:vmHostDscConfigContent.Append("        }`r`n")
+
+    [void] $script:vmHostDscConfigContent.Append("    }`r`n")
+    [void] $script:vmHostDscConfigContent.Append("}`r`n`r`n")
+
+    [void] $script:vmHostDscConfigContent.Append("$script:vmHostConfigurationName -ConfigurationData `$script:configurationData")
+
+    $outputFile = $OutputPath + $script:vmHostConfigurationFileName
+    $script:vmHostDscConfigContent.ToString() | Out-File -FilePath $outputFile -Encoding Default
+
+    Disconnect-VSphereServer
+}
+
+Export-VMHostConfiguration

--- a/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
+++ b/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
@@ -1535,6 +1535,25 @@ function Read-VMHostConfiguration {
 <#
 .DESCRIPTION
 
+Returns the path to the output file of the VMHost DSC Configuration.
+#>
+function Get-VMHostDscConfigurationOutputFile {
+    [CmdletBinding()]
+    [OutputType([string])]
+    Param()
+
+    $vmHostDscConfigurationOutputFile = $OutputPath
+    if (!$OutputPath.EndsWith('\') -and !$OutputPath.EndsWith('/')) {
+        $vmHostDscConfigurationOutputFile += '\'
+    }
+
+    $vmHostDscConfigurationOutputFile += $script:vmHostConfigurationFileName
+    $vmHostDscConfigurationOutputFile
+}
+
+<#
+.DESCRIPTION
+
 The main function for extracting the VMHost DSC Configuration. It acts as a call dispatcher, calling all required functions
 in the proper order to get the full Configuration.
 #>
@@ -1560,7 +1579,7 @@ function Export-VMHostConfiguration {
 
     [void] $script:vmHostDscConfigContent.Append("$script:vmHostConfigurationName -ConfigurationData `$script:configurationData")
 
-    $outputFile = $OutputPath + $script:vmHostConfigurationFileName
+    $outputFile = Get-VMHostDscConfigurationOutputFile
     $script:vmHostDscConfigContent.ToString() | Out-File -FilePath $outputFile -Encoding Default
 
     Disconnect-VSphereServer

--- a/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
+++ b/Source/VMware.vSphereDSC/ExportVMHostConfiguration.ps1
@@ -1199,7 +1199,7 @@ function Read-VMHostCache {
             Server = $Server
             Credential = $Credential
             Name = $VMHostName
-            Datastore = $datastoreName
+            DatastoreName = $datastoreName
         }
 
         $vmHostCacheDscResource = New-Object -TypeName 'VMHostCache' -Property $vmHostCacheDscResourceKeyProperties

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostCache/VMHostCache_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostCache/VMHostCache_Config.ps1
@@ -61,7 +61,7 @@ Configuration VMHostCache_WhenSwapSizeIsZeroGigabytes_Config {
             Name = $Name
             Server = $Server
             Credential = $script:viServerCredential
-            Datastore = $DatastoreName
+            DatastoreName = $DatastoreName
             SwapSizeGB = $script:zeroGigabytesSwapSize
         }
     }
@@ -75,7 +75,7 @@ Configuration VMHostCache_WhenSwapSizeIsOneGigabyte_Config {
             Name = $Name
             Server = $Server
             Credential = $script:viServerCredential
-            Datastore = $DatastoreName
+            DatastoreName = $DatastoreName
             SwapSizeGB = $script:oneGigabyteSwapSize
         }
     }
@@ -89,7 +89,7 @@ Configuration VMHostCache_WhenSwapSizeIsTwoGigabytes_Config {
             Name = $Name
             Server = $Server
             Credential = $script:viServerCredential
-            Datastore = $DatastoreName
+            DatastoreName = $DatastoreName
             SwapSizeGB = $script:twoGigabytesSwapSize
         }
     }

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostCache.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostCache.Integration.Tests.ps1
@@ -107,7 +107,7 @@ try {
                 # Assert
                 $configuration.Server | Should -Be $Server
                 $configuration.Name | Should -Be $Name
-                $configuration.Datastore | Should -Be $script:datastoreName
+                $configuration.DatastoreName | Should -Be $script:datastoreName
                 $configuration.SwapSizeGB | Should -Be $script:zeroGigabytesSwapSize
             }
 
@@ -160,7 +160,7 @@ try {
                 # Assert
                 $configuration.Server | Should -Be $Server
                 $configuration.Name | Should -Be $Name
-                $configuration.Datastore | Should -Be $script:datastoreName
+                $configuration.DatastoreName | Should -Be $script:datastoreName
                 $configuration.SwapSizeGB | Should -Be $script:oneGigabyteSwapSize
             }
 
@@ -228,7 +228,7 @@ try {
                 # Assert
                 $configuration.Server | Should -Be $Server
                 $configuration.Name | Should -Be $Name
-                $configuration.Datastore | Should -Be $script:datastoreName
+                $configuration.DatastoreName | Should -Be $script:datastoreName
                 $configuration.SwapSizeGB | Should -Be $script:twoGigabytesSwapSize
             }
 

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostCacheMocks.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostCacheMocks.ps1
@@ -44,7 +44,7 @@ function New-MocksWhenPassedSwapSizeIsNegative {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.NegativeSwapSize
 
     $datastoreMock = $script:datastore
@@ -59,7 +59,7 @@ function New-MocksWhenPassedSwapSizeIsBiggerThanDatastoreFreeSpace {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.OverflowingSwapSize
 
     $datastoreMock = $script:datastore
@@ -74,7 +74,7 @@ function New-MocksWhenUpdateCacheConfigurationResultsInError {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.SwapSizeGB
 
     $datastoreMock = $script:datastore
@@ -94,7 +94,7 @@ function New-MocksWhenUpdateCacheConfigurationResultsInSuccess {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.SwapSizeGB
 
     $datastoreMock = $script:datastore
@@ -114,7 +114,7 @@ function New-MocksWhenSwapSizeIsNotEqualToCurrentSwapSize {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.SwapSizeGB * 2
 
     $datastoreMock = $script:datastore
@@ -129,7 +129,7 @@ function New-MocksWhenSwapSizeIsEqualToCurrentSwapSize {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.SwapSizeGB
 
     $datastoreMock = $script:datastore
@@ -144,7 +144,7 @@ function New-MocksInGet {
     [OutputType([System.Collections.Hashtable])]
 
     $vmHostCacheProperties = New-VMHostCacheProperties
-    $vmHostCacheProperties.Datastore = $script:constants.DatastoreName
+    $vmHostCacheProperties.DatastoreName = $script:constants.DatastoreName
     $vmHostCacheProperties.SwapSizeGB = $script:constants.SwapSizeGB
 
     $datastoreMock = $script:datastore

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostCache.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostCache.Unit.Tests.ps1
@@ -255,7 +255,7 @@ InModuleScope -ModuleName $script:moduleName {
                 # Assert
                 $result.Server | Should -Be $resourceProperties.Server
                 $result.Name | Should -Be $script:constants.VMHostName
-                $result.Datastore | Should -Be $script:datastore.Name
+                $result.DatastoreName | Should -Be $script:datastore.Name
                 $result.SwapSizeGB | Should -Be $script:constants.SwapSizeGB
             }
         }


### PR DESCRIPTION
### Added
- Added a script that exports the VMHost state as a DSC Configuration.

### Changed
- Modified DatastoreName and FileName properties of VMHostVMKernelDumpFile to be **Key** instead of **Mandatory**.
- Renamed Datastore property of VMHostCache DSC Resource to DatastoreName.
- Fixed bug with nullable NoTraps property of VMHostSNMPAgent DSC Resource.
- Fixed bug with nullable properties for VMHostSyslog DSC Resource.
