### PR TITLE
ConnectionFilter for vSphere Nodes

### DIFF
--- a/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
+++ b/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
@@ -285,7 +285,7 @@ class DscConfigurationCompiler {
         $dscNodes = $this.CombineNodes($dscItems)
 
         for ($i = 0; $i -lt $dscNodes.Length; $i++) {
-            Write-Verbose ("Ordering Resources of node with name: " + $dscNodes[$i].InstanceName)
+            Write-Verbose ("Ordering DSC Resources of node: " + $dscNodes[$i].InstanceName)
 
             # parse the dsc resources and their dependencies into a sorted array
             $dscNodes[$i].Resources = $this.OrderResources($dscNodes[$i].Resources)
@@ -992,21 +992,21 @@ class DscTestMethodDetailedResult : BaseDscMethodResult {
 .DESCRIPTION
 Type used for checking uniqueness of dsc resource key properties
 #>
-class KeyPropertyResourceCheck {
-    [string] $ResourceType
+class DscKeyPropertyResourceCheck {
+    [string] $DscResourceType
       
     # can contain only string, int, enum values, because only properties of those types can be keys
     [Hashtable] $KeyPropertiesToValues
 
-    KeyPropertyResourceCheck([string] $ResourceType, [Hashtable] $KeyPropertiesToValues) {
-        $this.ResourceType = $ResourceType
+    DscKeyPropertyResourceCheck([string] $DscResourceType, [Hashtable] $KeyPropertiesToValues) {
+        $this.DscResourceType = $DscResourceType
         $this.KeyPropertiesToValues = $KeyPropertiesToValues
     }
 
     [bool] Equals([Object] $other) {
-        $other = $other -as [KeyPropertyResourceCheck]
+        $other = $other -as [DscKeyPropertyResourceCheck]
 
-        if (-not $this.ResourceType.Equals($other.ResourceType)) {
+        if (-not $this.DscResourceType.Equals($other.DscResourceType)) {
             return $false
         }
 
@@ -1240,7 +1240,7 @@ class DscConfigurationRunner {
     #>
     hidden [void] ValidateDscKeyProperties([VmwDscResource[]] $DscResources) {
         $resourcesQueue = New-Object 'System.Collections.Queue'
-        $dscResourcesDuplicateChecker = New-Object 'System.Collections.Generic.HashSet[KeyPropertyResourceCheck]'
+        $dscResourcesDuplicateChecker = New-Object 'System.Collections.Generic.HashSet[DscKeyPropertyResourceCheck]'
 
         $resourcesQueue.Enqueue($DscResources)
 
@@ -1268,9 +1268,9 @@ class DscConfigurationRunner {
     <#
     .DESCRIPTION
     Finds the key properties of a dsc resource and
-    wraps it in a KeyPropertyResourceCheck object with the resource type and key props array.
+    wraps it in a DscKeyPropertyResourceCheck object with the resource type and key props array.
     #>
-    hidden [KeyPropertyResourceCheck] GetDscResouceKeyProperties([VmwDscResource] $DscResource) {
+    hidden [DscKeyPropertyResourceCheck] GetDscResouceKeyProperties([VmwDscResource] $DscResource) {
         $moduleName = $DscResource.ModuleName.Name
         $moduleVersion = $DscResource.ModuleName.RequiredVersion.ToString()
 
@@ -1314,7 +1314,7 @@ class DscConfigurationRunner {
             $dscResourceKeyPropertiesHashTable[$dscKeyProp] = $DscResource.Property[$dscKeyProp]
         }
 
-        $resourceCheck = [KeyPropertyResourceCheck]::new(
+        $resourceCheck = [DscKeyPropertyResourceCheck]::new(
             $DscResource.ResourceType,
             $dscResourceKeyPropertiesHashTable
         )

--- a/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
+++ b/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
@@ -1004,23 +1004,21 @@ class DscKeyPropertyResourceCheck {
     }
 
     [bool] Equals([Object] $other) {
+        $comparisonResult = $true
         $other = $other -as [DscKeyPropertyResourceCheck]
 
         if (-not $this.DscResourceType.Equals($other.DscResourceType)) {
-            return $false
-        }
-
-        foreach ($key in $this.KeyPropertiesToValues.Keys) {
-            if (-not $other.KeyPropertiesToValues.ContainsKey($key)) {
-                return $false
-            }
-
-            if (-not $this.KeyPropertiesToValues[$key].Equals($other.KeyPropertiesToValues[$key])) {
-                return $false
+            $comparisonResult = $false
+        } else {
+            foreach ($key in $this.KeyPropertiesToValues.Keys) {
+                if ((-not $other.KeyPropertiesToValues.ContainsKey($key)) -or (-not $this.KeyPropertiesToValues[$key].Equals($other.KeyPropertiesToValues[$key]))) {
+                    $comparisonResult = $false
+                    break
+                }
             }
         }
 
-        return $true
+        return $comparisonResult
     }
 
     [int] GetHashCode() {

--- a/VMware.PSDesiredStateConfiguration.md
+++ b/VMware.PSDesiredStateConfiguration.md
@@ -160,7 +160,11 @@ $config = New-VmwDscConfiguration @vmwDscConfigParams
 These cmdlets work with the PowerShell object created by **New-VmwDscConfiguration** and apply the Set, Test, Get **DSC methods** to the compiled configuration.
 
 ##### Parameters
-- **Configuration** - A Dsc Configuration compiled by **New-VmwDscConfiguration**
+##### Mandatory
+- **Configuration** - A DSC Configuration object compiled by **New-VmwDscConfiguration**
+
+#### Optional
+- **ConnectionFilter** - An array of node names that should be executed. Nodes that are not in the list will be skipped. Node names can be in the form of strings or ViConnection objects. 
 
 ---
 ### Examples
@@ -208,7 +212,7 @@ These cmdlets work with the PowerShell object created by **New-VmwDscConfigurati
     ```
     The resulting object will contain an **InDesiredState** flag which shows the overall state of the configuration, a **ResourcesInDesiredState** array of resources in desired state and a **ResourcesNotInDesiredState** array of resources not in desired state.
     
-    Test-VmwDscConfiguration also remembers the last run configuration so you can use the -ExecuteLastConfiguration flag to invoke it.
+    **Test-VmwDscConfiguration** also remembers the last run configuration so you can use the -ExecuteLastConfiguration flag to invoke it.
     ```powershell
     Test-VmwDscConfiguration -ExecuteLastConfiguration
     ```
@@ -216,12 +220,42 @@ These cmdlets work with the PowerShell object created by **New-VmwDscConfigurati
     ```powershell
     Start-VmwDscConfiguration -Configuration $dscConfiguration
     ```
-5. To get the latest applied configuration on your machine:
+5. To get the current sate of the configuration:
     ```powershell
     Get-VmwDscConfiguration -Configuration $dscConfiguration
     ```
     
-    Get-VmwDscConfiguration also remembers the last run configuration so you can use the -ExecuteLastConfiguration flag to invoke it.
+    **Get-VmwDscConfiguration** also remembers the last run configuration so you can use the -ExecuteLastConfiguration flag to invoke it.
     ```powershell
     Get-VmwDscConfiguration -ExecuteLastConfiguration
     ```
+##### Example with ConnectionFilter parameter
+
+The following configuration has multiple nodes. Only the nodes specified in **ConnectionFilter**
+will be executed.
+
+```powershell
+Configuration Test {
+    Import-DscResource -ModuleName 'MyDscResourceModule'
+    
+    Node 'mynode' {
+        MyResource res {
+            Prop = 'Test'
+        }
+    }
+    Node 'other node' {
+        MyResource res {
+            Prop = 'Test'
+        }
+    }
+}
+
+$dscConfiguration = New-VmwDscConfiguration -ConfigName 'Test'
+
+$splatParams = @{
+    Configuration = $dscConfiguration
+    ConnectionFilter = 'other node'
+}
+
+$result = Start-VmwDscConfiguration @$splatParams
+```


### PR DESCRIPTION
### Added
- **ConnectionFilter** parameter was added to the **Start, Test and Get-VmwDscConfiguration** cmdlets, which gives the option to choose the **vSphere Nodes** on which the configuration will be executed.

### Changed
- Extend the **New-VmwDscConfiguration** cmdlet to have **Verbose** output.
