### PR TITLE
Extend VMHostVDSwitchMigration DSC Resource to create distributed port groups with VLAN ID

### DIFF
--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.ps1
@@ -202,7 +202,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     #>
     [PSObject] GetStandardPortGroup($standardPortGroupName) {
         try {
-            Write-VerboseLog -Message $this.RetrieveStandardPortGroupMessage -Arguments @($standardPortGroupName, $this.VMHost.Name)
+            $this.WriteLogUtil('Verbose', $this.RetrieveStandardPortGroupMessage, @($standardPortGroupName, $this.VMHost.Name))
             $getVirtualPortGroupParams = @{
                 Server = $this.Connection
                 Name = $standardPortGroupName
@@ -420,7 +420,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
                 }
             }
 
-            Write-VerboseLog -Message $this.CreateVDPortGroupMessage -Arguments @($distributedPortGroupName, $distributedSwitch.Name, $createVDPortGroupMessageEnd)
+            $this.WriteLogUtil('Verbose', $this.CreateVDPortGroupMessage, @($distributedPortGroupName, $distributedSwitch.Name, $createVDPortGroupMessageEnd))
             return New-VDPortgroup @newVDPortGroupParams
         }
         catch {

--- a/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.ps1
+++ b/Source/VMware.vSphereDSC/DSCResources/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.ps1
@@ -48,7 +48,8 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     [nullable[bool]] $MigratePhysicalNicsOnly
 
     hidden [string] $RetrieveVDSwitchMessage = "Retrieving VDSwitch {0} from vCenter {1}."
-    hidden [string] $CreateVDPortGroupMessage = "Creating VDPortGroup {0} on VDSwitch {1}."
+    hidden [string] $RetrieveStandardPortGroupMessage = "Retrieving Standard Port Group {0} located on VMHost {1}."
+    hidden [string] $CreateVDPortGroupMessage = "Creating VDPortGroup {0} on VDSwitch {1}{2}"
     hidden [string] $AddVDSwitchToVMHostMessage = "Adding VDSwitch {0} to VMHost {1}."
     hidden [string] $AddPhysicalNicsToVDSwitchMessage = "Migrating Physical Network Adapters {0} to VDSwitch {1}."
     hidden [string] $AddPhysicalNicsAndVMKernelNicsToVDSwitchMessage = "Migrating Physical Network Adapters {0} and VMKernel Network Adapters {1} to VDSwitch {2}."
@@ -56,6 +57,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     hidden [string] $MigratePhysicalNicsOnlyNotSpecified = "When migrating Physical Network Adapters without VMKernel Network Adapters, the MigratePhysicalNicsOnly parameter should be specified in order for the migration to occur."
 
     hidden [string] $CouldNotRetrieveVDSwitchMessage = "Could not retrieve VDSwitch {0}. For more information: {1}"
+    hidden [string] $CouldNotRetrieveStandardPortGroupMessage = "Could not retrieve Standard Port Group {0} located on VMHost {1}. For more information: {2}"
     hidden [string] $CouldNotCreateVDPortGroupMessage = "Could not create VDPortGroup {0} on VDSwitch {1}. For more information: {2}"
     hidden [string] $CouldNotAddVDSwitchToVMHostMessage = "Could not add VDSwitch {0} to VMHost {1}. For more information: {2}"
     hidden [string] $CouldNotAddPhysicalNicsToVDSwitchMessage = "Could not migrate Physical Network Adapters {0} to VDSwitch {1}. For more information: {2}"
@@ -195,6 +197,31 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     <#
     .DESCRIPTION
 
+    Retrieves the Standard Port Group with the specified name if it exists.
+    Otherwise it throws an exception.
+    #>
+    [PSObject] GetStandardPortGroup($standardPortGroupName) {
+        try {
+            Write-VerboseLog -Message $this.RetrieveStandardPortGroupMessage -Arguments @($standardPortGroupName, $this.VMHost.Name)
+            $getVirtualPortGroupParams = @{
+                Server = $this.Connection
+                Name = $standardPortGroupName
+                VMHost = $this.VMHost
+                Standard = $true
+                ErrorAction = 'Stop'
+                Verbose = $false
+            }
+
+            return Get-VirtualPortGroup @getVirtualPortGroupParams
+        }
+        catch {
+            throw ($this.CouldNotRetrieveStandardPortGroupMessage -f $standardPortGroupName, $this.VMHost.Name, $_.Exception.Message)
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
     Creates a hashtable containing the parameters for the Add-VDSwitchPhysicalNetworkAdapter cmdlet.
     #>
     [hashtable] GetAddVDSwitchPhysicalNetworkAdapterParams($distributedSwitch, $physicalNics) {
@@ -319,7 +346,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     Ensures that the specified Distributed Port Groups exist. If a Distributed Port Group is specified and does not exist,
     it is created on the specified Distributed Switch.
     #>
-    [array] EnsureDistributedPortGroupsExist($distributedSwitch) {
+    [array] EnsureDistributedPortGroupsExist($distributedSwitch, $vmKernelNetworkAdapters) {
         $portGroups = @()
         foreach ($distributedPortGroupName in $this.PortGroupNames) {
             $getVDPortGroupParams = @{
@@ -331,22 +358,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
             }
             $distributedPortGroup = Get-VDPortgroup @getVDPortGroupParams
             if ($null -eq $distributedPortGroup) {
-                try {
-                    $this.WriteLogUtil('Verbose', $this.CreateVDPortGroupMessage, @($distributedPortGroupName, $distributedSwitch.Name))
-
-                    $newVDPortGroupParams = @{
-                        Server = $this.Connection
-                        Name = $distributedPortGroupName
-                        VDSwitch = $distributedSwitch
-                        Confirm = $false
-                        ErrorAction = 'Stop'
-                        Verbose = $false
-                    }
-                    $distributedPortGroup = New-VDPortgroup @newVDPortGroupParams
-                }
-                catch {
-                    throw ($this.CouldNotCreateVDPortGroupMessage -f $distributedPortGroupName, $distributedSwitch.Name, $_.Exception.Message)
-                }
+                $distributedPortGroup = $this.CreateDistributedPortGroup($distributedPortGroupName, $distributedSwitch, $vmKernelNetworkAdapters)
             }
 
             $portGroups += $distributedPortGroup
@@ -374,6 +386,45 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
             if ($this.PortGroupNames.Length -ne 0) {
                 throw "$($this.PortGroupNames.Length) Port Groups specified and no VMKernel Network Adapters specified which is not valid."
             }
+        }
+    }
+
+    <#
+    .DESCRIPTION
+
+    Creates a new Distributed Port Group with the specified name on the specified Distributed Switch.
+    If a Standard Port Group with the same name exists on the Standard Switch from which the VMKernel Network Adapters are migrated
+    and the Standard Port Group is associated with a VLAN, the new Distributed Port Group is created with the same VLAN to avoid
+    any network misconfigurations due to VLANs not configured correctly.
+    #>
+    [PSObject] CreateDistributedPortGroup($distributedPortGroupName, $distributedSwitch, $vmKernelNetworkAdapters) {
+        try {
+            $createVDPortGroupMessageEnd = "."
+            $newVDPortGroupParams = @{
+                Server = $this.Connection
+                Name = $distributedPortGroupName
+                VDSwitch = $distributedSwitch
+                Confirm = $false
+                ErrorAction = 'Stop'
+                Verbose = $false
+            }
+
+            $vmKernelNetworkAdapterOfStandardPortGroup = $vmKernelNetworkAdapters | Where-Object -FilterScript { $_.PortGroupName -eq $distributedPortGroupName }
+            if ($null -ne $vmKernelNetworkAdapterOfStandardPortGroup) {
+                $standardPortGroup = $this.GetStandardPortGroup($distributedPortGroupName)
+
+                # The VLAN for Distributed Port Groups is valid only in the specified range.
+                if ($standardPortGroup.VLanId -In 1..4094) {
+                    $newVDPortGroupParams.VlanId = $standardPortGroup.VLanId
+                    $createVDPortGroupMessageEnd = " with VLAN ID $($standardPortGroup.VLanId)."
+                }
+            }
+
+            Write-VerboseLog -Message $this.CreateVDPortGroupMessage -Arguments @($distributedPortGroupName, $distributedSwitch.Name, $createVDPortGroupMessageEnd)
+            return New-VDPortgroup @newVDPortGroupParams
+        }
+        catch {
+            throw ($this.CouldNotCreateVDPortGroupMessage -f $distributedPortGroupName, $distributedSwitch.Name, $_.Exception.Message)
         }
     }
 
@@ -440,7 +491,7 @@ class VMHostVDSwitchMigration : VMHostNetworkMigrationBaseDSC {
     Adds the Physical Network Adapters and VMKernel Network Adapters to the specified Distributed Switch.
     #>
     [void] AddPhysicalNetworkAdaptersAndVMKernelNetworkAdaptersToDistributedSwitch($physicalNetworkAdapters, $vmKernelNetworkAdapters, $distributedSwitch) {
-        $portGroups = $this.EnsureDistributedPortGroupsExist($distributedSwitch)
+        $portGroups = $this.EnsureDistributedPortGroupsExist($distributedSwitch, $vmKernelNetworkAdapters)
 
         try {
             $this.WriteLogUtil('Verbose', $this.AddPhysicalNicsAndVMKernelNicsToVDSwitchMessage, @(

--- a/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/Configurations/VMHostVDSwitchMigration/VMHostVDSwitchMigration_Config.ps1
@@ -33,6 +33,7 @@ Configuration VMHostVDSwitchMigration_CreateStandardSwitchStandardPortGroupVDSwi
             Name = $AllNodes.PortGroupName
             VssName = $AllNodes.StandardSwitchName
             Ensure = 'Present'
+            VLanId = $AllNodes.PortGroupVLanId
             DependsOn = $AllNodes.VMHostVssResourceId
         }
 
@@ -107,6 +108,7 @@ Configuration VMHostVDSwitchMigration_MigrateOneDisconnectedPhysicalNetworkAdapt
             VMHostName = $AllNodes.VMHostName
             VdsName = $AllNodes.VDSwitchName
             PhysicalNicNames = @($AllNodes.PhysicalNetworkAdapterNames[0])
+            MigratePhysicalNicsOnly = $AllNodes.MigratePhysicalNicsOnly
         }
     }
 }
@@ -121,6 +123,7 @@ Configuration VMHostVDSwitchMigration_MigrateTwoDisconnectedPhysicalNetworkAdapt
             VMHostName = $AllNodes.VMHostName
             VdsName = $AllNodes.VDSwitchName
             PhysicalNicNames = @($AllNodes.PhysicalNetworkAdapterNames[0], $AllNodes.PhysicalNetworkAdapterNames[1])
+            MigratePhysicalNicsOnly = $AllNodes.MigratePhysicalNicsOnly
         }
     }
 }
@@ -135,6 +138,7 @@ Configuration VMHostVDSwitchMigration_MigrateTwoDisconnectedAndOneConnectedPhysi
             VMHostName = $AllNodes.VMHostName
             VdsName = $AllNodes.VDSwitchName
             PhysicalNicNames = $AllNodes.PhysicalNetworkAdapterNames
+            MigratePhysicalNicsOnly = $AllNodes.MigratePhysicalNicsOnly
         }
     }
 }

--- a/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Integration/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Integration.Tests.ps1
@@ -77,10 +77,12 @@ $script:configurationData = @{
             LinkDiscoveryProtocolOperation = 'Listen'
             LinkDiscoveryProtocolProtocol = 'CDP'
             PortGroupName = 'Management Network'
+            PortGroupVLanId = 4094
             ManagementPortGroupName = 'MyManagementPortGroup'
             VMotionPortGroupName = 'MyvMotionPortGroup'
             ManagementTrafficEnabled = $true
             VMotionEnabled = $true
+            MigratePhysicalNicsOnly = $true
         }
     )
 }

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/MockData.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/MockData.ps1
@@ -204,8 +204,11 @@ $script:constants = @{
     DisconnectedPhysicalNetworkAdapterBitRatePerSecMb = 0
     VMKernelNetworkAdapterOneName = 'MyVMKernelNetworkAdapterOne'
     VMKernelNetworkAdapterTwoName = 'MyVMKernelNetworkAdapterTwo'
+    VMKernelNicAttachedToPortGroupWithVLanName = 'MyVMKernelNetworkAdapterAttachedToPortGroupWithVLanName'
     PortGroupOneName = 'MyPortGroupOneName'
     PortGroupTwoName = 'MyPortGroupTwoName'
+    PortGroupWithVLanName = 'MyPortGroupWithVLanName'
+    PortGroupWithVLanVLanId = 4094
     DistributedSwitchWithoutAddedPhysicalNetworkAdaptersName = 'MyDistributedSwitchWithoutAddedPhysicalNetworkAdapters'
     DomainName = 'MyDomain'
     DomainUsername = 'MyDomainUsername'
@@ -1158,6 +1161,17 @@ $script:vmKernelNetworkAdapterTwo = [VMware.VimAutomation.ViCore.Impl.V1.Host.Ne
     Name = $script:constants.VMKernelNetworkAdapterTwoName
     VMHost = $script:vmHostAddedToDistributedSwitchOne
     PortGroupName = $script:constants.PortGroupTwoName
+}
+
+$script:vmKernelNicAttachedToPortGroupWithVLan = [VMware.VimAutomation.ViCore.Impl.V1.Host.Networking.Nic.HostVMKernelVirtualNicImpl] @{
+    Name = $script:constants.VMKernelNicAttachedToPortGroupWithVLanName
+    VMHost = $script:vmHostAddedToDistributedSwitchOne
+    PortGroupName = $script:constants.PortGroupWithVLanName
+}
+
+$script:portGroupWithVLan = [VMware.VimAutomation.ViCore.Impl.V1.Host.Networking.VirtualPortGroupImpl] @{
+    Name = $script:constants.PortGroupWithVLanName
+    VLanId = $script:constants.PortGroupWithVLanVLanId
 }
 
 $script:distributedSwitchWithoutAddedPhysicalNetworkAdapters = [VMware.VimAutomation.Vds.Impl.V1.VmwareVDSwitchImpl] @{

--- a/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVDSwitchMigrationMocks.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/TestHelpers/Mocks/VMHostVDSwitchMigrationMocks.ps1
@@ -378,6 +378,30 @@ function New-MocksWhenTwoConnectedAndOneDisconnectedPhysicalNetworkAdaptersTwoVM
     $vmHostVDSwitchMigrationProperties
 }
 
+function New-MocksWhenPortGroupWithAssociatedVLanIsPassed {
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+
+    $vmHostVDSwitchMigrationProperties = New-VMHostVDSwitchMigrationProperties
+
+    $vmHostVDSwitchMigrationProperties.PhysicalNicNames = @($script:constants.DisconnectedPhysicalNetworkAdapterOneName)
+    $vmHostVDSwitchMigrationProperties.VMKernelNicNames = @($script:constants.VMKernelNicAttachedToPortGroupWithVLanName)
+    $vmHostVDSwitchMigrationProperties.PortGroupNames = @($script:constants.PortGroupWithVLanName)
+
+    $physicalNetworkAdapterMock = $script:disconnectedPhysicalNetworkAdapterOne
+    $vmKernelNetworkAdapterMock = $script:vmKernelNicAttachedToPortGroupWithVLan
+    $standardPortGroupMock = $script:portGroupWithVLan
+
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $physicalNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.DisconnectedPhysicalNetworkAdapterOneName -and $VMHost -eq $script:vmHostAddedToDistributedSwitchOne -and $Physical } -Verifiable
+    Mock -CommandName Get-VMHostNetworkAdapter -MockWith { return $vmKernelNetworkAdapterMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.VMKernelNicAttachedToPortGroupWithVLanName -and $VMHost -eq $script:vmHostAddedToDistributedSwitchOne -and $VMKernel } -Verifiable
+    Mock -CommandName Get-VDPortgroup -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupWithVLanName -and $VDSwitch -eq $script:distributedSwitch } -Verifiable
+    Mock -CommandName Get-VirtualPortGroup -MockWith { return $standardPortGroupMock }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupWithVLanName -and $VMHost -eq $script:vmHostAddedToDistributedSwitchOne -and $Standard } -Verifiable
+    Mock -CommandName New-VDPortgroup -MockWith { return $null }.GetNewClosure() -ParameterFilter { $Server -eq $script:viServer -and $Name -eq $script:constants.PortGroupWithVLanName -and $VDSwitch -eq $script:distributedSwitch -and $VlanId -eq $script:constants.PortGroupWithVLanVLanId } -Verifiable
+    Mock -CommandName Add-VDSwitchPhysicalNetworkAdapter -MockWith { return $null }.GetNewClosure() -Verifiable
+
+    $vmHostVDSwitchMigrationProperties
+}
+
 function New-MocksWhenVMHostIsNotAddedToTheDistributedSwitch {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]

--- a/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Unit.Tests.ps1
+++ b/Source/VMware.vSphereDSC/Tests/Unit/VMHostNetwork/VMHostNetworkMigration/VMHostVDSwitchMigration.Unit.Tests.ps1
@@ -535,6 +535,47 @@ InModuleScope -ModuleName $script:moduleName {
                     Assert-MockCalled @assertMockCalledParams
                 }
             }
+
+            Context 'Port Group with associated VLan is passed' {
+                BeforeAll {
+                    # Arrange
+                    $resourceProperties = New-MocksWhenPortGroupWithAssociatedVLanIsPassed
+                    $resource = New-Object -TypeName $resourceName -Property $resourceProperties
+                }
+
+                It 'Should call all defined mocks with the correct parameters' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    Assert-VerifiableMock
+                }
+
+                It 'Should call the Add-VDSwitchPhysicalNetworkAdapter mock with the Distributed Switch, the disconnected Physical Network Adapter, the VMKernel Network Adapter and the Port Group with VLan once' {
+                    # Act
+                    $resource.Set()
+
+                    # Assert
+                    $expectedVMHostPhysicalNic = @($script:disconnectedPhysicalNetworkAdapterOne)
+                    $expectedVMHostVirtualNic = @($script:vmKernelNicAttachedToPortGroupWithVLan)
+
+                    $assertMockCalledParams = @{
+                        CommandName = 'Add-VDSwitchPhysicalNetworkAdapter'
+                        ParameterFilter = {
+                            $Server -eq $script:viServer -and
+                            $DistributedSwitch -eq $script:distributedSwitch -and
+                            [System.Linq.Enumerable]::SequenceEqual($VMHostPhysicalNic, [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.Nic.PhysicalNic[]] $expectedVMHostPhysicalNic) -and
+                            [System.Linq.Enumerable]::SequenceEqual($VMHostVirtualNic, [VMware.VimAutomation.ViCore.Types.V1.Host.Networking.Nic.HostVirtualNic[]] $expectedVMHostVirtualNic) -and
+                            !$Confirm
+                        }
+                        Exactly = $true
+                        Times = 1
+                        Scope = 'It'
+                    }
+
+                    Assert-MockCalled @assertMockCalledParams
+                }
+            }
         }
 
         Describe 'VMHostVDSwitchMigration\Test' -Tag 'Test' {


### PR DESCRIPTION
### Changed
- Extended **VMHostVDSwitchMigration DSC Resource** to create distributed port groups with **VLAN ID**.
