### PR TITLE
[Bug fix] Extend key property validation with null check in VMware.PSDesiredStateConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+<<<<<<< HEAD
 ## VMware.PSDesiredStateConfiguration 0.0.0.10 - 2021-01-25
 ### Changed
 - Modified the **License** logic in the **VMware.PSDesiredStateConfiguration** build to cut the first two lines of the **License** in **License.txt**.
@@ -11,6 +12,8 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Removed unused **ExperimentalEnabled** script.
 
+=======
+>>>>>>> 4591ae9 (sync upstream with origin)
 ## VMware.PSDesiredStateConfiguration 0.0.0.9 - 2021-01-23
 ### Changed
 - Fix bug with exceptions not being thrown when an error occurs in a **DSC Resource** when invoking the **DSC Configuration** through the **VMware.PSDesiredStateConfiguration** module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 ## VMware.PSDesiredStateConfiguration 0.0.0.10 - 2021-01-25
 ### Changed
 - Modified the **License** logic in the **VMware.PSDesiredStateConfiguration** build to cut the first two lines of the **License** in **License.txt**.
@@ -13,10 +11,6 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Removed unused **ExperimentalEnabled** script.
 
-=======
->>>>>>> 4591ae9 (sync upstream with origin)
-=======
->>>>>>> 19ec592578d4e37edca0cef2098ddd12eb60b3f0
 ## VMware.PSDesiredStateConfiguration 0.0.0.9 - 2021-01-23
 ### Changed
 - Fix bug with exceptions not being thrown when an error occurs in a **DSC Resource** when invoking the **DSC Configuration** through the **VMware.PSDesiredStateConfiguration** module.

--- a/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
+++ b/Source/VMware.PSDesiredStateConfiguration/Classes/DscItems.ps1
@@ -1453,6 +1453,10 @@ class DscConfigurationRunner {
         $dscResourceKeyPropertiesHashTable = @{}
 
         foreach ($dscKeyProp in $dscResourceKeyProperties) {
+            if ($null -eq $DscResource.Property[$dscKeyProp]) {
+               # DSC Key Property cannot be null, throw configuration error
+               throw "Incorrect DSC Configuration: Key Property '$dscKeyProp' of resource $($DscResource.GetId()) is NULL"
+            }
             $dscResourceKeyPropertiesHashTable[$dscKeyProp] = $DscResource.Property[$dscKeyProp]
         }
 


### PR DESCRIPTION
### Changed
- Extended the validation of the key properties of a **DSC Resource** in the **VMware.PSDesiredStateConfiguration** module to throw an exception when a key property is **$null**.
