### PR TITLE
[Impovement] Add CompatiblePSEditions to VMware.vSphereDSC and VMware.PSDesiredStateConfiguration module manifests

### DIFF
--- a/Source/VMware.PSDesiredStateConfiguration/VMware.PSDesiredStateConfiguration.psd1
+++ b/Source/VMware.PSDesiredStateConfiguration/VMware.PSDesiredStateConfiguration.psd1
@@ -19,7 +19,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 ModuleToProcess = 'VMware.PSDesiredStateConfiguration.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0.14'
+ModuleVersion = '0.0.0.14'
 
 # ID used to uniquely identify this module
 GUID = '4f9a62bf-e2a6-4bd1-ac20-ccf127bc643e'
@@ -29,6 +29,9 @@ Author = 'VMware'
 
 # Company or vendor of this module
 CompanyName = 'VMware'
+
+# Supported PSEditions
+CompatiblePSEditions = 'Desktop', 'Core'
 
 # Copyright statement for this module
 Copyright = '(c) VMware. All rights reserved.'

--- a/Source/VMware.vSphereDSC/VMware.vSphereDSC.psd1
+++ b/Source/VMware.vSphereDSC/VMware.vSphereDSC.psd1
@@ -20,7 +20,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 RootModule = 'VMware.vSphereDSC.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.0.83'
+ModuleVersion = '2.1.0.83'
 
 # ID used to uniquely identify this module
 GUID = '664b57b4-bd8d-4a56-9984-278f7fe10cf8'
@@ -30,6 +30,9 @@ Author = 'VMware'
 
 # Company or vendor of this module
 CompanyName = 'VMware'
+
+# Supported PSEditions
+CompatiblePSEditions = 'Desktop', 'Core'
 
 # Copyright statement for this module
 Copyright = '(c) 2018-2020 VMware. All rights reserved.'


### PR DESCRIPTION
### Changed
- Modified the **VMware.vSphereDSC** and **VMware.PSDesiredStateConfiguration** module manifests to contain the **CompatiblePSEditions** module manifest key with both values: **Desktop** and **Core**.
