### PR TITLE
Making sure that both Configuration and configuration work

### DIFF
--- a/Source/VMware.PSDesiredStateConfiguration/Classes/Public/DscConfigurationFileParser.ps1
+++ b/Source/VMware.PSDesiredStateConfiguration/Classes/Public/DscConfigurationFileParser.ps1
@@ -55,7 +55,7 @@ class DscConfigurationFileParser {
                 $dscConfigurationsContentAsString = $dscConfigurationsContent.ToString()
 
                 # Only the content of the DSC Configuration is needed so we trim the Configuration keyword and the name of the DSC Configuration.
-                $dscConfigurationsContentAsString = $dscConfigurationsContentAsString.TrimStart('Configuration').TrimStart()
+                $dscConfigurationsContentAsString = $dscConfigurationsContentAsString.TrimStart('Cconfiguration').TrimStart()
                 $dscConfigurationsContentAsString = $dscConfigurationsContentAsString.TrimStart($dscConfigurations[$j].Name).TrimStart()
 
                 $dscConfigurationsContentAsString = $dscConfigurationsContentAsString.TrimEnd()


### PR DESCRIPTION
While working with VMware DSC in PowerShell 7 I noticed a weird issue where creating configuration with lower case keyword would result in an error.
It appears that for whatever reason, configuration keyword is removed using TrimStart. IMO, that is a terrible choice:
- it takes a list of chars, not a string, so it's only coincidental it works as expected
- it is case-sensitive, making language case-sensitive too (resulting in the issue like the one I faced).

To limit the amount of changes, I'm simply adding lower case `c` to the list of chars that are being trimmed, but I'd suggest using something different entirely to replace any combination of CoNfIgUrAtIoN that authors may come up with, as PowerShell is for sure not case-sensitive in the keyword realm, but VMware DSC appears to be exactly that.